### PR TITLE
Added POWER7+ intrinsincs and cpu detection to makefile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+cmake_minimum_required(VERSION 2.8.7)
+
 set (randomx_sources
 src/aes_hash.cpp
 src/argon2_ref.c
@@ -47,6 +49,14 @@ src/reciprocal.c
 src/virtual_machine.cpp
 src/vm_compiled_light.cpp
 src/blake2/blake2b.c)
+
+if (NOT ARCH_ID)
+  set(ARCH_ID ${CMAKE_HOST_SYSTEM_PROCESSOR})
+endif()
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
 
 if (ARCH_ID STREQUAL "x86_64" OR ARCH_ID STREQUAL "x86-64" OR ARCH_ID STREQUAL "amd64")
   list(APPEND randomx_sources

--- a/makefile
+++ b/makefile
@@ -22,6 +22,14 @@ ifeq ($(PLATFORM),x86_64)
     CXXFLAGS += -maes
 endif
 
+ifeq ($(PLATFORM),ppc64)
+    CXXFLAGS += -mcpu=native
+endif
+
+ifeq ($(PLATFORM),ppc64le)
+    CXXFLAGS += -mcpu=native
+endif
+
 release: CXXFLAGS += -O3 -flto
 release: CCFLAGS += -O3 -flto
 release: LDFLAGS += -flto


### PR DESCRIPTION
Added altivec functions to support future jit compiler. Sadly IBM's AES implementation is not compatible with intels, see https://stackoverflow.com/questions/56027569/is-there-a-fast-way-to-make-ibms-vncipher-instruction-result-the-same-as-intels