### PR TITLE
Add Dataset prefetch in interpreted VM

### DIFF
--- a/src/vm_interpreted.cpp
+++ b/src/vm_interpreted.cpp
@@ -246,6 +246,7 @@ namespace randomx {
 
 			mem.mx ^= r[config.readReg2] ^ r[config.readReg3];
 			mem.mx &= CacheLineAlignMask;
+			datasetPrefetch(datasetOffset + mem.mx);
 			datasetRead(datasetOffset + mem.ma, r);
 			std::swap(mem.mx, mem.ma);
 
@@ -277,6 +278,11 @@ namespace randomx {
 		uint64_t* datasetLine = (uint64_t*)(mem.memory + address);
 		for (int i = 0; i < RegistersCount; ++i)
 			r[i] ^= datasetLine[i];
+	}
+
+	template<class Allocator, bool softAes>
+	void InterpretedVm<Allocator, softAes>::datasetPrefetch(uint64_t address) {
+		rx_prefetch_nta(mem.memory + address);
 	}
 
 #include "instruction_weights.hpp"

--- a/src/vm_interpreted.hpp
+++ b/src/vm_interpreted.hpp
@@ -81,6 +81,7 @@ namespace randomx {
 		void setDataset(randomx_dataset* dataset) override;
 	protected:
 		virtual void datasetRead(uint64_t blockNumber, int_reg_t(&r)[RegistersCount]);
+		virtual void datasetPrefetch(uint64_t blockNumber);
 	private:
 		void execute();
 		void precompileProgram(int_reg_t(&r)[RegistersCount], rx_vec_f128(&f)[RegisterCountFlt], rx_vec_f128(&e)[RegisterCountFlt], rx_vec_f128(&a)[RegisterCountFlt]);

--- a/src/vm_interpreted_light.hpp
+++ b/src/vm_interpreted_light.hpp
@@ -51,6 +51,7 @@ namespace randomx {
 		void setCache(randomx_cache* cache) override;
 	protected:
 		void datasetRead(uint64_t address, int_reg_t(&r)[8]) override;
+		void datasetPrefetch(uint64_t address) override { }
 	};
 
 	using InterpretedLightVmDefault = InterpretedLightVm<AlignedAllocator<CacheLineSize>, true>;


### PR DESCRIPTION
* to formally match the specification
* a small increase in interpreted mining speed (~4%)