### PR TITLE
benchmark: add thread affinity mask option

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,6 +2,7 @@
 #CC=gcc-8
 AR=gcc-ar
 PLATFORM=$(shell uname -m)
+OS=$(shell uname -s)
 CXXFLAGS=-std=c++11
 CCFLAGS=-std=c99
 ARFLAGS=rcs
@@ -20,6 +21,9 @@ endif
 ifeq ($(PLATFORM),x86_64)
     RXOBJS += $(addprefix $(OBJDIR)/,jit_compiler_x86_static.o jit_compiler_x86.o)
     CXXFLAGS += -maes
+endif
+ifeq ($(OS),Darwin)
+    AR=ar
 endif
 
 release: CXXFLAGS += -O3 -flto
@@ -54,10 +58,10 @@ $(OBJDIR):
 $(BINDIR):
 	mkdir $(BINDIR)
 $(OBJDIR)/benchmark.o: $(TESTDIR)/benchmark.cpp $(TESTDIR)/stopwatch.hpp \
- $(TESTDIR)/utility.hpp $(SRCDIR)/randomx.h $(SRCDIR)/blake2/endian.h
+ $(TESTDIR)/utility.hpp $(SRCDIR)/randomx.h $(SRCDIR)/blake2/endian.h $(SRCDIR)/affinity.hpp
 	$(CXX) $(CXXFLAGS) -pthread -c $< -o $@
-$(BINDIR)/benchmark: $(OBJDIR)/benchmark.o $(RXA)
-	$(CXX) $(LDFLAGS) -pthread $< $(RXA) -o $@
+$(BINDIR)/benchmark: $(OBJDIR)/benchmark.o $(OBJDIR)/affinity.o $(RXA)
+	$(CXX) $(LDFLAGS) -pthread $< $(OBJDIR)/affinity.o $(RXA) -o $@
 $(OBJDIR)/code-generator.o: $(TESTDIR)/code-generator.cpp $(TESTDIR)/utility.hpp \
  $(SRCDIR)/common.hpp $(SRCDIR)/blake2/endian.h \
  $(SRCDIR)/configuration.h $(SRCDIR)/randomx.h \
@@ -105,6 +109,7 @@ $(OBJDIR)/vm_interpreted.o: $(SRCDIR)/vm_interpreted.cpp $(SRCDIR)/vm_interprete
  $(SRCDIR)/intrin_portable.h $(SRCDIR)/allocator.hpp $(SRCDIR)/dataset.hpp \
  $(SRCDIR)/superscalar_program.hpp $(SRCDIR)/jit_compiler_x86.hpp $(SRCDIR)/reciprocal.h \
  $(SRCDIR)/instruction_weights.hpp
+$(OBJDIR/affinity.o: $(SRCDIR)/affinity.cpp $(SRCDIR)/affinity.hpp
 $(OBJDIR)/allocator.o: $(SRCDIR)/allocator.cpp $(SRCDIR)/allocator.hpp $(SRCDIR)/intrin_portable.h \
  $(SRCDIR)/virtual_memory.hpp $(SRCDIR)/common.hpp $(SRCDIR)/blake2/endian.h \
  $(SRCDIR)/configuration.h $(SRCDIR)/randomx.h

--- a/src/affinity.cpp
+++ b/src/affinity.cpp
@@ -1,0 +1,114 @@
+/*
+Copyright (c) 2019, jtgrassie
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the copyright holder nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+  #include <windows.h>
+#else
+  #ifdef __APPLE__
+    #include <mach/thread_act.h>
+    #include <mach/thread_policy.h>
+  #endif
+  #include <pthread.h>
+#endif
+#include "affinity.hpp"
+
+int
+set_thread_affinity(const unsigned &cpuid)
+{
+    std::thread::native_handle_type thread;
+#if defined(_WIN32) || defined(__CYGWIN__)
+    thread = static_cast<std::thread::native_handle_type>(GetCurrentThread());
+#else
+    thread = static_cast<std::thread::native_handle_type>(pthread_self());
+#endif
+    return set_thread_affinity(thread, cpuid);
+}
+
+int
+set_thread_affinity(std::thread::native_handle_type thread,
+        const unsigned &cpuid)
+{
+    int rc = -1;
+#ifdef __APPLE__
+    thread_port_t mach_thread;
+    thread_affinity_policy_data_t policy = { static_cast<integer_t>(cpuid) };
+    mach_thread = pthread_mach_thread_np(thread);
+    rc = thread_policy_set(mach_thread, THREAD_AFFINITY_POLICY,
+            (thread_policy_t)&policy, 1);
+#elif defined(_WIN32) || defined(__CYGWIN__)
+    rc = SetThreadAffinityMask(thread, 1ULL << cpuid) == 0 ? -2 : 0;
+#else
+    cpu_set_t cs;
+    CPU_ZERO(&cs);
+    CPU_SET(cpuid, &cs);
+    rc = pthread_setaffinity_np(thread, sizeof(cpu_set_t), &cs);
+#endif
+    return rc;
+}
+
+unsigned
+cpuid_from_mask(uint64_t mask, const unsigned &thread_index)
+{
+    static unsigned lookup[64];
+    static bool init = false;
+    if (init)
+        return lookup[thread_index];
+    unsigned count_found = 0;
+    for (unsigned i=0; i<64; i++)
+    {
+        if (1ULL & mask)
+        {
+            lookup[count_found] = i;
+            count_found++;
+        }
+        mask >>= 1;
+    }
+    init = true;
+    return lookup[thread_index];
+}
+
+std::string
+mask_to_string(uint64_t mask)
+{
+    std::string r(65, '\0');
+    unsigned len = 0;
+    unsigned v = 0;
+    unsigned i = 64;
+    while (i--)
+    {
+        v = mask >> i;
+        if (1ULL & v)
+        {
+            if (len == 0) len = i+1;
+            r[len-i] = '1';
+        }
+        else
+            if (len > 0) r[len-i] = '0';
+    }
+    return r;
+}

--- a/src/affinity.hpp
+++ b/src/affinity.hpp
@@ -1,0 +1,39 @@
+/*
+Copyright (c) 2019, jtgrassie
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the copyright holder nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <thread>
+#include <string>
+
+int set_thread_affinity(const unsigned &cpuid);
+int set_thread_affinity(std::thread::native_handle_type thread,
+        const unsigned &cpuid);
+unsigned cpuid_from_mask(uint64_t mask, const unsigned &thread_index);
+std::string mask_to_string(uint64_t mask);

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -69,7 +69,7 @@ namespace randomx {
 	static_assert(wtSum == 256,	"Sum of instruction frequencies must be 256.");
 
 
-	constexpr int ArgonBlockSize = 1024;
+	constexpr uint32_t ArgonBlockSize = 1024;
 	constexpr int ArgonSaltSize = sizeof("" RANDOMX_ARGON_SALT) - 1;
 	constexpr int SuperscalarMaxSize = 3 * RANDOMX_SUPERSCALAR_LATENCY + 2;
 	constexpr int CacheLineSize = RANDOMX_DATASET_ITEM_SIZE;
@@ -84,7 +84,7 @@ namespace randomx {
 
 	//Prevent some unsafe configurations.
 #ifndef RANDOMX_UNSAFE
-	static_assert(RANDOMX_CACHE_ACCESSES * RANDOMX_ARGON_MEMORY * ArgonBlockSize + 33554432 >= RANDOMX_DATASET_BASE_SIZE + RANDOMX_DATASET_EXTRA_SIZE, "Unsafe configuration: Memory-time tradeoffs");
+	static_assert((uint64_t)ArgonBlockSize * RANDOMX_CACHE_ACCESSES * RANDOMX_ARGON_MEMORY + 33554432 >= (uint64_t)RANDOMX_DATASET_BASE_SIZE + RANDOMX_DATASET_EXTRA_SIZE, "Unsafe configuration: Memory-time tradeoffs");
 	static_assert((128 + RANDOMX_PROGRAM_SIZE * RANDOMX_FREQ_ISTORE / 256) * (RANDOMX_PROGRAM_COUNT * RANDOMX_PROGRAM_ITERATIONS) >= RANDOMX_SCRATCHPAD_L3, "Unsafe configuration: Insufficient Scratchpad writes");
 	static_assert(RANDOMX_PROGRAM_COUNT > 1, "Unsafe configuration: Program filtering strategies");
 	static_assert(RANDOMX_PROGRAM_SIZE >= 64, "Unsafe configuration: Low program entropy");

--- a/src/tests/utility.hpp
+++ b/src/tests/utility.hpp
@@ -66,6 +66,15 @@ inline void readIntOption(const char* option, int argc, char** argv, int& out, i
 	out = defaultValue;
 }
 
+inline void readUInt64Option(const char* option, int argc, char** argv, uint64_t& out, uint64_t defaultValue) {
+	for (int i = 0; i < argc - 1; ++i) {
+		if (strcmp(argv[i], option) == 0 && (out = std::strtoull(argv[i + 1], NULL, 0)) > 0) {
+			return;
+		}
+	}
+	out = defaultValue;
+}
+
 inline void readFloatOption(const char* option, int argc, char** argv, double& out, double defaultValue) {
 	for (int i = 0; i < argc - 1; ++i) {
 		if (strcmp(argv[i], option) == 0 && (out = atof(argv[i + 1])) > 0) {


### PR DESCRIPTION
Adds a thread affinity mask option for allowing to set miner threads to specific cpus/cores. Accepts a hex or decimal value representing a bitmask.

E.g. `--threads 4 --affinity 0x1D`, equates to our 4 threads `t1,t2,t3,t4` and a mask `11101`, which yields: ` (t4, cpu4), (t3, cpu3), (t2, cpu2), (t1, cpu0)`. So cpu is the bit position (right-to-left) and each `1` sequentially is the next thread.

Useful for benchmarking multi-processor/NUMA node systems.
