### PR TITLE
Different round keys for columns 0,1 and 2,3 in AesGenerator4R

### DIFF
--- a/doc/specs.md
+++ b/doc/specs.md
@@ -169,41 +169,46 @@ state0 (16 B)    state1 (16 B)    state2 (16 B)    state3 (16 B)
 
 ### 3.3 AesGenerator4R
 
-AesGenerator4R works the same way as AesGenerator1R, except it uses 4 rounds per column:
+AesGenerator4R works similar way as AesGenerator1R, except it uses 4 rounds per column. Columns 0 and 1 use a different set of keys than columns 2 and 3.
 
 ```
 state0 (16 B)    state1 (16 B)    state2 (16 B)    state3 (16 B)
      |                |                |                |
  AES decrypt      AES encrypt      AES decrypt      AES encrypt
-   (key0)           (key0)           (key0)           (key0)
+   (key0)           (key0)           (key4)           (key4)
      |                |                |                |
      v                v                v                v
  AES decrypt      AES encrypt      AES decrypt      AES encrypt
-   (key1)           (key1)           (key1)           (key1)
+   (key1)           (key1)           (key5)           (key5)
      |                |                |                |
      v                v                v                v
  AES decrypt      AES encrypt      AES decrypt      AES encrypt
-   (key2)           (key2)           (key2)           (key2)
+   (key2)           (key2)           (key6)           (key6)
      |                |                |                |
      v                v                v                v
  AES decrypt      AES encrypt      AES decrypt      AES encrypt
-   (key3)           (key3)           (key3)           (key3)
+   (key3)           (key3)           (key7)           (key7)
      |                |                |                |
      v                v                v                v
   state0'          state1'          state2'          state3'
 ```
 
-AesGenerator4R uses the following 4 round keys:
+AesGenerator4R uses the following 8 round keys:
 
 ```
-key0 = 5d 46 90 f8 a6 e4 fb 7f b7 82 1f 14 95 9e 35 cf
-key1 = 50 c4 55 6a 8a 27 e8 fe c3 5a 5c bd dc ff 41 67
-key2 = a4 47 4c 11 e4 fd 24 d5 d2 9a 27 a7 ac 4a 32 3d
-key3 = 2a 3a 0c 81 ff ae a9 99 d9 db d3 42 08 db f6 76
+key0 = dd aa 21 64 db 3d 83 d1 2b 6d 54 2f 3f d2 e5 99
+key1 = 50 34 0e b2 55 3f 91 b6 53 9d f7 06 e5 cd df a5
+key2 = 04 d9 3e 5c af 7b 5e 51 9f 67 a4 0a bf 02 1c 17
+key3 = 63 37 62 85 08 5d 8f e7 85 37 67 cd 91 d2 de d8
+key4 = 73 6f 82 b5 a6 a7 d6 e3 6d 8b 51 3d b4 ff 9e 22
+key5 = f3 6b 56 c7 d9 b3 10 9c 4e 4d 02 e9 d2 b7 72 b2
+key6 = e7 c9 73 f2 8b a3 65 f7 0a 66 a9 2b a7 ef 3b f6
+key7 = 09 d6 7c 7a de 39 58 91 fd d1 06 0c 2d 76 b0 c0
 ```
 These keys were generated as:
 ```
-key0, key1, key2, key3 = Hash512("RandomX AesGenerator4R keys")
+key0, key1, key2, key3 = Hash512("RandomX AesGenerator4R keys 0-3")
+key4, key5, key6, key7 = Hash512("RandomX AesGenerator4R keys 4-7")
 ```
 
 ### 3.4 AesHash1R

--- a/src/aes_hash.cpp
+++ b/src/aes_hash.cpp
@@ -157,10 +157,14 @@ void fillAes1Rx4(void *state, size_t outputSize, void *buffer) {
 template void fillAes1Rx4<true>(void *state, size_t outputSize, void *buffer);
 template void fillAes1Rx4<false>(void *state, size_t outputSize, void *buffer);
 
-#define AES_GEN_4R_KEY0 0xcf359e95, 0x141f82b7, 0x7ffbe4a6, 0xf890465d
-#define AES_GEN_4R_KEY1 0x6741ffdc, 0xbd5c5ac3, 0xfee8278a, 0x6a55c450
-#define AES_GEN_4R_KEY2 0x3d324aac, 0xa7279ad2, 0xd524fde4, 0x114c47a4
-#define AES_GEN_4R_KEY3 0x76f6db08, 0x42d3dbd9, 0x99a9aeff, 0x810c3a2a
+#define AES_GEN_4R_KEY0 0x99e5d23f, 0x2f546d2b, 0xd1833ddb, 0x6421aadd
+#define AES_GEN_4R_KEY1 0xa5dfcde5, 0x06f79d53, 0xb6913f55, 0xb20e3450
+#define AES_GEN_4R_KEY2 0x171c02bf, 0x0aa4679f, 0x515e7baf, 0x5c3ed904
+#define AES_GEN_4R_KEY3 0xd8ded291, 0xcd673785, 0xe78f5d08, 0x85623763
+#define AES_GEN_4R_KEY4 0x229effb4, 0x3d518b6d, 0xe3d6a7a6, 0xb5826f73
+#define AES_GEN_4R_KEY5 0xb272b7d2, 0xe9024d4e, 0x9c10b3d9, 0xc7566bf3
+#define AES_GEN_4R_KEY6 0xf63befa7, 0x2ba9660a, 0xf765a38b, 0xf273c9e7
+#define AES_GEN_4R_KEY7 0xc0b0762d, 0x0c06d1fd, 0x915839de, 0x7a7cd609
 
 template<bool softAes>
 void fillAes4Rx4(void *state, size_t outputSize, void *buffer) {
@@ -168,12 +172,16 @@ void fillAes4Rx4(void *state, size_t outputSize, void *buffer) {
 	const uint8_t* outputEnd = outptr + outputSize;
 
 	rx_vec_i128 state0, state1, state2, state3;
-	rx_vec_i128 key0, key1, key2, key3;
+	rx_vec_i128 key0, key1, key2, key3, key4, key5, key6, key7;
 
 	key0 = rx_set_int_vec_i128(AES_GEN_4R_KEY0);
 	key1 = rx_set_int_vec_i128(AES_GEN_4R_KEY1);
 	key2 = rx_set_int_vec_i128(AES_GEN_4R_KEY2);
 	key3 = rx_set_int_vec_i128(AES_GEN_4R_KEY3);
+	key4 = rx_set_int_vec_i128(AES_GEN_4R_KEY4);
+	key5 = rx_set_int_vec_i128(AES_GEN_4R_KEY5);
+	key6 = rx_set_int_vec_i128(AES_GEN_4R_KEY6);
+	key7 = rx_set_int_vec_i128(AES_GEN_4R_KEY7);
 
 	state0 = rx_load_vec_i128((rx_vec_i128*)state + 0);
 	state1 = rx_load_vec_i128((rx_vec_i128*)state + 1);
@@ -183,23 +191,23 @@ void fillAes4Rx4(void *state, size_t outputSize, void *buffer) {
 	while (outptr < outputEnd) {
 		state0 = aesdec<softAes>(state0, key0);
 		state1 = aesenc<softAes>(state1, key0);
-		state2 = aesdec<softAes>(state2, key0);
-		state3 = aesenc<softAes>(state3, key0);
+		state2 = aesdec<softAes>(state2, key4);
+		state3 = aesenc<softAes>(state3, key4);
 
 		state0 = aesdec<softAes>(state0, key1);
 		state1 = aesenc<softAes>(state1, key1);
-		state2 = aesdec<softAes>(state2, key1);
-		state3 = aesenc<softAes>(state3, key1);
+		state2 = aesdec<softAes>(state2, key5);
+		state3 = aesenc<softAes>(state3, key5);
 
 		state0 = aesdec<softAes>(state0, key2);
 		state1 = aesenc<softAes>(state1, key2);
-		state2 = aesdec<softAes>(state2, key2);
-		state3 = aesenc<softAes>(state3, key2);
+		state2 = aesdec<softAes>(state2, key6);
+		state3 = aesenc<softAes>(state3, key6);
 
 		state0 = aesdec<softAes>(state0, key3);
 		state1 = aesenc<softAes>(state1, key3);
-		state2 = aesdec<softAes>(state2, key3);
-		state3 = aesenc<softAes>(state3, key3);
+		state2 = aesdec<softAes>(state2, key7);
+		state3 = aesenc<softAes>(state3, key7);
 
 		rx_store_vec_i128((rx_vec_i128*)outptr + 0, state0);
 		rx_store_vec_i128((rx_vec_i128*)outptr + 1, state1);

--- a/src/tests/benchmark.cpp
+++ b/src/tests/benchmark.cpp
@@ -241,7 +241,7 @@ int main(int argc, char** argv) {
 		std::cout << "Calculated result: ";
 		result.print(std::cout);
 		if (noncesCount == 1000 && seedValue == 0)
-			std::cout << "Reference result:  669ae4f2e5e2c0d9cc232ff2c37d41ae113fa302bbf983d9f3342879831b4edf" << std::endl;
+			std::cout << "Reference result:  a925d346195ef38048e714709e0b24a88fef565fa02fa97127e00fac08ee6eb8" << std::endl;
 		if (!miningMode) {
 			std::cout << "Performance: " << 1000 * elapsed / noncesCount << " ms per hash" << std::endl;
 		}

--- a/src/tests/rng-tests.cpp
+++ b/src/tests/rng-tests.cpp
@@ -1,0 +1,93 @@
+/*
+  cd ~
+  wget http://simul.iro.umontreal.ca/testu01/TestU01.zip
+  unzip TestU01.zip
+  mkdir TestU01
+  cd TestU01-1.2.3
+  ./configure --prefix=`pwd`/../TestU01
+  make -j8
+  make install
+  cd ~/RandomX
+  g++ -O3 src/tests/rng-tests.cpp -lm -I ~/TestU01/include -L ~/TestU01/lib -L bin/ -l:libtestu01.a -l:libmylib.a -l:libprobdist.a -lrandomx -o bin/rng-tests -DRANDOMX_GEN=4R -DRANDOMX_TESTU01=Crush
+  bin/rng-tests 0
+*/
+
+extern "C" {
+  #include "unif01.h"
+  #include "bbattery.h"
+}
+
+#include "../aes_hash.hpp"
+#include "../blake2/blake2.h"
+#include "utility.hpp"
+#include <cstdint>
+
+#ifndef RANDOMX_GEN
+#error Please define RANDOMX_GEN with a value of 1R or 4R
+#endif
+
+#ifndef RANDOMX_TESTU01
+#error Please define RANDOMX_TESTU01 with a value of SmallCrush, Crush or BigCrush
+#endif
+
+#define STR(x) #x
+#define CONCAT(a,b,c) a ## b ## c
+#define GEN_NAME(x) "AesGenerator" STR(x)
+#define GEN_FUNC(x) CONCAT(fillAes, x, x4)
+#define TEST_SUITE(x) CONCAT(bbattery_, x,)
+
+constexpr int GeneratorStateSize = 64;
+constexpr int GeneratorCapacity = GeneratorStateSize / sizeof(uint32_t);
+
+static unsigned long aesGenBits(void *param, void *state) {
+  uint32_t* statePtr = (uint32_t*)state;
+  int* indexPtr = (int*)param;
+  int stateIndex = *indexPtr;
+  if(stateIndex >= GeneratorCapacity) {
+    GEN_FUNC(RANDOMX_GEN)<false>(statePtr, GeneratorStateSize, statePtr);
+    stateIndex = 0;
+  }
+  uint32_t next = statePtr[stateIndex];
+  *indexPtr = stateIndex + 1;
+  return next;
+}
+
+static double aesGenDouble(void *param, void *state) {
+  return aesGenBits (param, state) / unif01_NORM32;
+}
+
+static void aesWriteState(void* state) {
+  char* statePtr = (char*)state;
+  for(int i = 0; i < 4; ++i) {
+    std::cout << "state" << i << " = ";
+    outputHex(std::cout, statePtr + (i * 16), 16);
+    std::cout << std::endl;
+  }
+}
+
+int main(int argc, char** argv) {
+  if (argc != 2) {
+    std::cout << argv[0] << " <seed>" << std::endl;
+    return 1;
+  }
+  uint32_t state[GeneratorCapacity] = { 0 };
+  int stateIndex = GeneratorCapacity;
+  char name[] = GEN_NAME(RANDOMX_GEN);
+  uint64_t seed = strtoull(argv[1], nullptr, 0);
+  if(seed) {
+    blake2b(&state, sizeof(state), &seed, sizeof(seed), nullptr, 0);
+  }
+  unif01_Gen gen;
+  gen.state = &state;
+  gen.param = &stateIndex;
+  gen.Write = &aesWriteState;
+  gen.GetU01 = &aesGenDouble;
+  gen.GetBits = &aesGenBits;
+  gen.name = (char*)name;
+
+  gen.Write(gen.state);
+  std::cout << std::endl;
+
+  TEST_SUITE(RANDOMX_TESTU01)(&gen);
+  return 0;
+}


### PR DESCRIPTION
* this fixes identical sequences of columns 0/2 and 1/3 if their states are the same
* added [TestU01](https://en.wikipedia.org/wiki/TestU01) results for AesGenerator1R and AesGenerator4R
* added a note about the reversibility of AesHash1R