### PR TITLE
Fix: possible overflow when using non-standard Dataset size

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -43,6 +43,7 @@ namespace randomx {
 	static_assert((RANDOMX_DATASET_BASE_SIZE & (RANDOMX_DATASET_BASE_SIZE - 1)) == 0, "RANDOMX_DATASET_BASE_SIZE must be a power of 2.");
 	static_assert(RANDOMX_DATASET_BASE_SIZE <= 4294967296ULL, "RANDOMX_DATASET_BASE_SIZE must not exceed 4294967296.");
 	static_assert(RANDOMX_DATASET_EXTRA_SIZE % 64 == 0, "RANDOMX_DATASET_EXTRA_SIZE must be divisible by 64.");
+	static_assert((uint64_t)RANDOMX_DATASET_BASE_SIZE + RANDOMX_DATASET_EXTRA_SIZE <= 17179869184, "Dataset size must not exceed 16 GiB.");
 	static_assert(RANDOMX_PROGRAM_SIZE > 0, "RANDOMX_PROGRAM_SIZE must be greater than 0");
 	static_assert(RANDOMX_PROGRAM_ITERATIONS > 0, "RANDOMX_PROGRAM_ITERATIONS must be greater than 0");
 	static_assert(RANDOMX_PROGRAM_COUNT > 0, "RANDOMX_PROGRAM_COUNT must be greater than 0");
@@ -72,7 +73,7 @@ namespace randomx {
 	constexpr uint32_t ArgonBlockSize = 1024;
 	constexpr int ArgonSaltSize = sizeof("" RANDOMX_ARGON_SALT) - 1;
 	constexpr int SuperscalarMaxSize = 3 * RANDOMX_SUPERSCALAR_LATENCY + 2;
-	constexpr int CacheLineSize = RANDOMX_DATASET_ITEM_SIZE;
+	constexpr size_t CacheLineSize = RANDOMX_DATASET_ITEM_SIZE;
 	constexpr int ScratchpadSize = RANDOMX_SCRATCHPAD_L3;
 	constexpr uint32_t CacheLineAlignMask = (RANDOMX_DATASET_BASE_SIZE - 1) & ~(CacheLineSize - 1);
 	constexpr uint32_t CacheSize = RANDOMX_ARGON_MEMORY * ArgonBlockSize;


### PR DESCRIPTION
Overflow is possible here if Dataset size is over 4 GiB.

https://github.com/tevador/RandomX/blob/2706a8b7533860900b33ac69899471e5127a4872/src/randomx.cpp#L123

Also added a `static_assert` to limit Dataset to a maximum of 16 GiB.