### PR TITLE
Do not attempt to allocate >= 4 GiB on 32-bit systems

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -31,7 +31,7 @@ Not all of the parameters can be changed safely and most parameters have some co
 This parameter determines the amount of memory needed in the light mode. Memory is specified in KiB (1 KiB = 1024 bytes).
 
 #### Permitted values
-Any integer power of 2.
+Integer powers of 2 in the range 1 - 2097152.
 
 #### Notes
 Lower sizes will reduce the memory-hardness of the algorithm.

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace randomx {
 
 	static_assert(RANDOMX_ARGON_MEMORY > 0, "RANDOMX_ARGON_MEMORY must be greater than 0.");
+	static_assert(RANDOMX_ARGON_MEMORY <= 2097152, "RANDOMX_ARGON_MEMORY must not exceed 2097152.");
 	static_assert((RANDOMX_ARGON_MEMORY & (RANDOMX_ARGON_MEMORY - 1)) == 0, "RANDOMX_ARGON_MEMORY must be a power of 2.");
 	static_assert(RANDOMX_DATASET_BASE_SIZE >= 64, "RANDOMX_DATASET_BASE_SIZE must be at least 64.");
 	static_assert((RANDOMX_DATASET_BASE_SIZE & (RANDOMX_DATASET_BASE_SIZE - 1)) == 0, "RANDOMX_DATASET_BASE_SIZE must be a power of 2.");

--- a/src/randomx.cpp
+++ b/src/randomx.cpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "vm_compiled_light.hpp"
 #include "blake2/blake2.h"
 #include <cassert>
+#include <limits>
 
 extern "C" {
 
@@ -102,6 +103,12 @@ extern "C" {
 	}
 
 	randomx_dataset *randomx_alloc_dataset(randomx_flags flags) {
+
+		//fail on 32-bit systems if DatasetSize is >= 4 GiB
+		if (randomx::DatasetSize > std::numeric_limits<size_t>::max()) {
+			return nullptr;
+		}
+
 		randomx_dataset *dataset;
 
 		try {


### PR DESCRIPTION
+ Cache size limited to 2 GiB