### PR TITLE
Fix for win32 build with gcc

### DIFF
--- a/src/instructions_portable.cpp
+++ b/src/instructions_portable.cpp
@@ -161,7 +161,7 @@ void rx_set_rounding_mode(uint32_t mode) {
 
 #ifdef RANDOMX_USE_X87
 
-#ifdef _M_IX86
+#if defined(_MSC_VER) && defined(_M_IX86)
 
 void rx_set_double_precision() {
 	_control87(_PC_53, _MCW_PC);

--- a/src/intrin_portable.h
+++ b/src/intrin_portable.h
@@ -61,7 +61,7 @@ constexpr int RoundToZero = 3;
 //the library "sqrt" function provided by MSVC for x86 targets doesn't give
 //the correct results, so we have to use inline assembly to call x87 fsqrt directly
 #if !defined(__SSE2__)
-#if defined(_M_IX86)
+#if defined(_MSC_VER) && defined(_M_IX86)
 inline double __cdecl rx_sqrt(double x) {
 	__asm {
 		fld x


### PR DESCRIPTION
Compiling with gcc on win32 is broken. This breaks gitian/depends builds of Monero.