### PR TITLE
Remember cache input data

### DIFF
--- a/src/dataset.hpp
+++ b/src/dataset.hpp
@@ -50,7 +50,7 @@ struct randomx_cache {
 	randomx::DatasetInitFunc* datasetInit;
 	randomx::SuperscalarProgram programs[RANDOMX_CACHE_ACCESSES];
 	std::vector<uint64_t> reciprocalCache;
-	std::string cacheData;
+	std::string cacheKey;
 
 	bool isInitialized() {
 		return programs[0].getSize() != 0;

--- a/src/dataset.hpp
+++ b/src/dataset.hpp
@@ -50,6 +50,7 @@ struct randomx_cache {
 	randomx::DatasetInitFunc* datasetInit;
 	randomx::SuperscalarProgram programs[RANDOMX_CACHE_ACCESSES];
 	std::vector<uint64_t> reciprocalCache;
+	std::string cacheData;
 
 	bool isInitialized() {
 		return programs[0].getSize() != 0;

--- a/src/randomx.cpp
+++ b/src/randomx.cpp
@@ -93,11 +93,11 @@ extern "C" {
 	void randomx_init_cache(randomx_cache *cache, const void *key, size_t keySize) {
 		assert(cache != nullptr);
 		assert(keySize == 0 || key != nullptr);
-		std::string data;
-		data.assign((const char *)key, keySize);
-		if (cache->cacheData != data) {
+		std::string cacheKey;
+		cacheKey.assign((const char *)key, keySize);
+		if (cache->cacheKey != cacheKey || !cache->isInitialized()) {
 			cache->initialize(cache, key, keySize);
-			cache->cacheData = data;
+			cache->cacheKey = cacheKey;
 		}
 	}
 
@@ -279,8 +279,10 @@ extern "C" {
 					UNREACHABLE;
 			}
 
-			if(cache != nullptr)
+			if(cache != nullptr) {
 				vm->setCache(cache);
+				vm->cacheKey = cache->cacheKey;
+			}
 
 			if(dataset != nullptr)
 				vm->setDataset(dataset);
@@ -298,9 +300,9 @@ extern "C" {
 	void randomx_vm_set_cache(randomx_vm *machine, randomx_cache* cache) {
 		assert(machine != nullptr);
 		assert(cache != nullptr && cache->isInitialized());
-		if (machine->cacheData != cache->cacheData) {
+		if (machine->cacheKey != cache->cacheKey) {
 			machine->setCache(cache);
-			machine->cacheData = cache->cacheData;
+			machine->cacheKey = cache->cacheKey;
 		}
 	}
 

--- a/src/randomx.cpp
+++ b/src/randomx.cpp
@@ -93,7 +93,12 @@ extern "C" {
 	void randomx_init_cache(randomx_cache *cache, const void *key, size_t keySize) {
 		assert(cache != nullptr);
 		assert(keySize == 0 || key != nullptr);
-		cache->initialize(cache, key, keySize);
+		std::string data;
+		data.assign((const char *)key, keySize);
+		if (cache->cacheData != data) {
+			cache->initialize(cache, key, keySize);
+			cache->cacheData = data;
+		}
 	}
 
 	void randomx_release_cache(randomx_cache* cache) {
@@ -293,7 +298,10 @@ extern "C" {
 	void randomx_vm_set_cache(randomx_vm *machine, randomx_cache* cache) {
 		assert(machine != nullptr);
 		assert(cache != nullptr && cache->isInitialized());
-		machine->setCache(cache);
+		if (machine->cacheData != cache->cacheData) {
+			machine->setCache(cache);
+			machine->cacheData = cache->cacheData;
+		}
 	}
 
 	void randomx_vm_set_dataset(randomx_vm *machine, randomx_dataset *dataset) {

--- a/src/randomx.h
+++ b/src/randomx.h
@@ -71,6 +71,7 @@ RANDOMX_EXPORT randomx_cache *randomx_alloc_cache(randomx_flags flags);
 
 /**
  * Initializes the cache memory and SuperscalarHash using the provided key value.
+ * Does nothing if called again with the same key value.
  *
  * @param cache is a pointer to a previously allocated randomx_cache structure. Must not be NULL.
  * @param key is a pointer to memory which contains the key value. Must not be NULL.
@@ -162,7 +163,8 @@ RANDOMX_EXPORT randomx_vm *randomx_create_vm(randomx_flags flags, randomx_cache 
 
 /**
  * Reinitializes a virtual machine with a new Cache. This function should be called anytime
- * the Cache is reinitialized with a new key.
+ * the Cache is reinitialized with a new key. Does nothing if called with a Cache containing
+ * the same key value as already set.
  *
  * @param machine is a pointer to a randomx_vm structure that was initialized
  *        without RANDOMX_FLAG_FULL_MEM. Must not be NULL.

--- a/src/virtual_machine.hpp
+++ b/src/virtual_machine.hpp
@@ -66,7 +66,7 @@ protected:
 	};
 	uint64_t datasetOffset;
 public:
-	std::string cacheData;
+	std::string cacheKey;
 };
 
 namespace randomx {

--- a/src/virtual_machine.hpp
+++ b/src/virtual_machine.hpp
@@ -65,6 +65,8 @@ protected:
 		randomx_dataset* datasetPtr;
 	};
 	uint64_t datasetOffset;
+public:
+	std::string cacheData;
 };
 
 namespace randomx {


### PR DESCRIPTION
Make init_cache and set_cache no-ops if fed the same data as before

This is just a suggestion; it could make some code in monerod a tiny bit simpler if we
didn't have to track cache contents so closely. (E.g. https://github.com/monero-project/monero/pull/5948) Feel free to close if not wanted.