### PR TITLE
Automatic detection of CPU capabilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ src/argon2_ref.c
 src/argon2_ssse3.c
 src/argon2_avx2.c
 src/bytecode_machine.cpp
+src/cpu.cpp
 src/dataset.cpp
 src/soft_aes.cpp
 src/virtual_memory.cpp
@@ -131,6 +132,13 @@ if (ARM_ID STREQUAL "aarch64" OR ARM_ID STREQUAL "arm64" OR ARM_ID STREQUAL "arm
     src/jit_compiler_a64.cpp)
   # cheat because cmake and ccache hate each other
   set_property(SOURCE src/jit_compiler_a64_static.S PROPERTY LANGUAGE C)
+
+  # not sure if this check is needed
+  include(CheckIncludeFile)
+  check_include_file(asm/hwcap.h HAVE_HWCAP)
+  if(HAVE_HWCAP)
+    add_definitions(-DHAVE_HWCAP)
+  endif()
 
   if(ARCH STREQUAL "native")
     add_flag("-march=native")

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -1,0 +1,72 @@
+/*
+Copyright (c) 2019, tevador <tevador@gmail.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the copyright holder nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "cpu.hpp"
+
+#if defined(_M_X64) || defined(__x86_64__)
+	#define HAVE_CPUID
+	#ifdef _WIN32
+		#include <intrin.h>
+		#define cpuid(info, x) __cpuidex(info, x, 0)
+	#else //GCC
+		#include <cpuid.h>
+		void cpuid(int info[4], int InfoType) {
+			__cpuid_count(InfoType, 0, info[0], info[1], info[2], info[3]);
+		}
+	#endif
+#endif
+
+#if defined(HAVE_HWCAP)
+	#include <sys/auxv.h>
+	#include <asm/hwcap.h>
+#endif
+
+namespace randomx {
+
+	Cpu::Cpu() : aes_(false), ssse3_(false), avx2_(false) {
+#ifdef HAVE_CPUID
+		int info[4];
+		cpuid(info, 0);
+		int nIds = info[0];
+		if (nIds >= 0x00000001) {
+			cpuid(info, 0x00000001);
+			ssse3_ = (info[2] & (1 << 9)) != 0;
+			aes_ = (info[2] & (1 << 25)) != 0;
+		}
+		if (nIds >= 0x00000007) {
+			cpuid(info, 0x00000007);
+			avx2_ = (info[1] & (1 << 5)) != 0;
+		}
+#elif defined(__aarch64__) && defined(HWCAP_AES)
+		long hwcaps = getauxval(AT_HWCAP);
+		aes_ = (hwcaps & HWCAP_AES) != 0;
+#endif
+		//TODO POWER8 AES
+	}
+
+}

--- a/src/cpu.hpp
+++ b/src/cpu.hpp
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2019, tevador <tevador@gmail.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the copyright holder nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+namespace randomx {
+
+	class Cpu {
+	public:
+		Cpu();
+		bool hasAes() const {
+			return aes_;
+		}
+		bool hasSsse3() const {
+			return ssse3_;
+		}
+		bool hasAvx2() const {
+			return avx2_;
+		}
+	private:
+		bool aes_, ssse3_, avx2_;
+	};
+
+}

--- a/src/dataset.hpp
+++ b/src/dataset.hpp
@@ -83,19 +83,12 @@ namespace randomx {
 	void initDataset(randomx_cache* cache, uint8_t* dataset, uint32_t startBlock, uint32_t endBlock);
 
 	inline randomx_argon2_impl* selectArgonImpl(randomx_flags flags) {
-		if ((flags & RANDOMX_FLAG_ARGON2) == 0) {
-			return &randomx_argon2_fill_segment_ref;
+		if (flags & RANDOMX_FLAG_ARGON2_AVX2) {
+			return randomx_argon2_impl_avx2();
 		}
-		randomx_argon2_impl* impl = nullptr;
-		if ((flags & RANDOMX_FLAG_ARGON2) == RANDOMX_FLAG_ARGON2_SSSE3) {
-			impl = randomx_argon2_impl_ssse3();
+		if (flags & RANDOMX_FLAG_ARGON2_SSSE3) {
+			return randomx_argon2_impl_ssse3();
 		}
-		if ((flags & RANDOMX_FLAG_ARGON2) == RANDOMX_FLAG_ARGON2_AVX2) {
-			impl = randomx_argon2_impl_avx2();
-		}
-		if (impl != nullptr) {
-			return impl;
-		}
-		throw std::runtime_error("Unsupported Argon2 implementation");
+		return &randomx_argon2_fill_segment_ref;
 	}
 }

--- a/src/intrin_portable.h
+++ b/src/intrin_portable.h
@@ -132,7 +132,7 @@ FORCE_INLINE rx_vec_f128 rx_set1_vec_f128(uint64_t x) {
 #define rx_aesenc_vec_i128 _mm_aesenc_si128
 #define rx_aesdec_vec_i128 _mm_aesdec_si128
 
-#define HAVE_AES
+#define HAVE_AES 1
 
 #endif //__AES__
 
@@ -303,7 +303,7 @@ FORCE_INLINE rx_vec_i128 rx_aesdec_vec_i128(rx_vec_i128 v, rx_vec_i128 rkey) {
 	__m128ll out = vrev((__m128i)__builtin_crypto_vncipher(_v,zero));
 	return (rx_vec_i128)vec_xor((__m128i)out,rkey);
 }
-#define HAVE_AES
+#define HAVE_AES 1
 
 #endif //__CRYPTO__
 
@@ -455,7 +455,7 @@ FORCE_INLINE rx_vec_i128 rx_aesdec_vec_i128(rx_vec_i128 a, rx_vec_i128 key) {
 	return vaesimcq_u8(vaesdq_u8(a, zero)) ^ key;
 }
 
-#define HAVE_AES
+#define HAVE_AES 1
 
 #endif
 
@@ -718,6 +718,9 @@ FORCE_INLINE rx_vec_i128 rx_aesenc_vec_i128(rx_vec_i128 v, rx_vec_i128 rkey) {
 FORCE_INLINE rx_vec_i128 rx_aesdec_vec_i128(rx_vec_i128 v, rx_vec_i128 rkey) {
 	throw std::runtime_error(platformError);
 }
+
+#define HAVE_AES 0
+
 #endif
 
 #ifdef RANDOMX_DEFAULT_FENV

--- a/src/randomx.cpp
+++ b/src/randomx.cpp
@@ -48,7 +48,7 @@ extern "C" {
 		if (randomx_argon2_impl_avx2() != nullptr && cpu.hasAvx2()) {
 			flags |= RANDOMX_FLAG_ARGON2_AVX2;
 		}
-		else if (randomx_argon2_impl_ssse3() != nullptr && cpu.hasSsse3()) {
+		if (randomx_argon2_impl_ssse3() != nullptr && cpu.hasSsse3()) {
 			flags |= RANDOMX_FLAG_ARGON2_SSSE3;
 		}
 		return flags;
@@ -56,10 +56,14 @@ extern "C" {
 
 	randomx_cache *randomx_alloc_cache(randomx_flags flags) {
 		randomx_cache *cache = nullptr;
+		auto impl = randomx::selectArgonImpl(flags);
+		if (impl == nullptr) {
+			return cache;
+		}
 
 		try {
 			cache = new randomx_cache();
-			cache->argonImpl = randomx::selectArgonImpl(flags);
+			cache->argonImpl = impl;
 			switch (flags & (RANDOMX_FLAG_JIT | RANDOMX_FLAG_LARGE_PAGES)) {
 				case RANDOMX_FLAG_DEFAULT:
 					cache->dealloc = &randomx::deallocCache<randomx::DefaultAllocator>;

--- a/src/randomx.cpp
+++ b/src/randomx.cpp
@@ -33,10 +33,26 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "vm_compiled.hpp"
 #include "vm_compiled_light.hpp"
 #include "blake2/blake2.h"
+#include "cpu.hpp"
 #include <cassert>
 #include <limits>
 
 extern "C" {
+
+	randomx_flags randomx_get_flags() {
+		randomx_flags flags = RANDOMX_HAVE_COMPILER ? RANDOMX_FLAG_JIT : RANDOMX_FLAG_DEFAULT;
+		randomx::Cpu cpu;
+		if (cpu.hasAes()) {
+			flags |= RANDOMX_FLAG_HARD_AES;
+		}
+		if (randomx_argon2_impl_avx2() != nullptr && cpu.hasAvx2()) {
+			flags |= RANDOMX_FLAG_ARGON2_AVX2;
+		}
+		else if (randomx_argon2_impl_ssse3() != nullptr && cpu.hasSsse3()) {
+			flags |= RANDOMX_FLAG_ARGON2_SSSE3;
+		}
+		return flags;
+	}
 
 	randomx_cache *randomx_alloc_cache(randomx_flags flags) {
 		randomx_cache *cache = nullptr;

--- a/src/randomx.cpp
+++ b/src/randomx.cpp
@@ -42,7 +42,7 @@ extern "C" {
 	randomx_flags randomx_get_flags() {
 		randomx_flags flags = RANDOMX_HAVE_COMPILER ? RANDOMX_FLAG_JIT : RANDOMX_FLAG_DEFAULT;
 		randomx::Cpu cpu;
-		if (cpu.hasAes()) {
+		if (HAVE_AES && cpu.hasAes()) {
 			flags |= RANDOMX_FLAG_HARD_AES;
 		}
 		if (randomx_argon2_impl_avx2() != nullptr && cpu.hasAvx2()) {

--- a/src/randomx.cpp
+++ b/src/randomx.cpp
@@ -64,7 +64,7 @@ extern "C" {
 		try {
 			cache = new randomx_cache();
 			cache->argonImpl = impl;
-			switch (flags & (RANDOMX_FLAG_JIT | RANDOMX_FLAG_LARGE_PAGES)) {
+			switch ((int)(flags & (RANDOMX_FLAG_JIT | RANDOMX_FLAG_LARGE_PAGES))) {
 				case RANDOMX_FLAG_DEFAULT:
 					cache->dealloc = &randomx::deallocCache<randomx::DefaultAllocator>;
 					cache->jit = nullptr;
@@ -193,7 +193,7 @@ extern "C" {
 		randomx_vm *vm = nullptr;
 
 		try {
-			switch (flags & (RANDOMX_FLAG_FULL_MEM | RANDOMX_FLAG_JIT | RANDOMX_FLAG_HARD_AES | RANDOMX_FLAG_LARGE_PAGES)) {
+			switch ((int)(flags & (RANDOMX_FLAG_FULL_MEM | RANDOMX_FLAG_JIT | RANDOMX_FLAG_HARD_AES | RANDOMX_FLAG_LARGE_PAGES))) {
 				case RANDOMX_FLAG_DEFAULT:
 					vm = new randomx::InterpretedLightVmDefault();
 					break;

--- a/src/randomx.h
+++ b/src/randomx.h
@@ -54,9 +54,37 @@ typedef struct randomx_dataset randomx_dataset;
 typedef struct randomx_cache randomx_cache;
 typedef struct randomx_vm randomx_vm;
 
+
 #if defined(__cplusplus)
+
+#ifdef __cpp_constexpr
+#define CONSTEXPR constexpr
+#else
+#define CONSTEXPR
+#endif
+
+inline CONSTEXPR randomx_flags operator |(randomx_flags a, randomx_flags b) {
+	return static_cast<randomx_flags>(static_cast<int>(a) | static_cast<int>(b));
+}
+inline CONSTEXPR randomx_flags operator &(randomx_flags a, randomx_flags b) {
+	return static_cast<randomx_flags>(static_cast<int>(a) & static_cast<int>(b));
+}
+inline randomx_flags& operator |=(randomx_flags& a, randomx_flags b) {
+	return a = a | b;
+}
+
 extern "C" {
 #endif
+
+/**
+ * @return The recommended flags to be used on the current machine.
+ *         Does not include:
+ *            RANDOMX_FLAG_LARGE_PAGES
+ *            RANDOMX_FLAG_FULL_MEM
+ *            RANDOMX_FLAG_SECURE
+ *         These flags must be added manually if desired.
+ */
+RANDOMX_EXPORT randomx_flags randomx_get_flags(void);
 
 /**
  * Creates a randomx_cache structure and allocates memory for RandomX Cache.

--- a/src/tests/api-example1.c
+++ b/src/tests/api-example1.c
@@ -6,9 +6,10 @@ int main() {
 	const char myInput[] = "RandomX example input";
 	char hash[RANDOMX_HASH_SIZE];
 
-	randomx_cache *myCache = randomx_alloc_cache(RANDOMX_FLAG_DEFAULT);
+	randomx_flags flags = randomx_get_flags();
+	randomx_cache *myCache = randomx_alloc_cache(flags);
 	randomx_init_cache(myCache, &myKey, sizeof myKey);
-	randomx_vm *myMachine = randomx_create_vm(RANDOMX_FLAG_DEFAULT, myCache, NULL);
+	randomx_vm *myMachine = randomx_create_vm(flags, myCache, NULL);
 
 	randomx_calculate_hash(myMachine, &myInput, sizeof myInput, hash);
 

--- a/src/tests/api-example2.cpp
+++ b/src/tests/api-example2.cpp
@@ -8,14 +8,17 @@ int main() {
 	const char myInput[] = "RandomX example input";
 	char hash[RANDOMX_HASH_SIZE];
 
-	randomx_cache *myCache = randomx_alloc_cache((randomx_flags)(RANDOMX_FLAG_JIT | RANDOMX_FLAG_LARGE_PAGES));
+	randomx_flags flags = randomx_get_flags();
+	flags |= RANDOMX_FLAG_LARGE_PAGES;
+	flags |= RANDOMX_FLAG_FULL_MEM;
+	randomx_cache *myCache = randomx_alloc_cache(flags);
 	if (myCache == nullptr) {
 		std::cout << "Cache allocation failed" << std::endl;
 		return 1;
 	}
 	randomx_init_cache(myCache, myKey, sizeof myKey);
 
-	randomx_dataset *myDataset = randomx_alloc_dataset(RANDOMX_FLAG_LARGE_PAGES);
+	randomx_dataset *myDataset = randomx_alloc_dataset(flags);
 	if (myDataset == nullptr) {
 		std::cout << "Dataset allocation failed" << std::endl;
 		return 1;
@@ -28,7 +31,7 @@ int main() {
 	t2.join();
 	randomx_release_cache(myCache);
 
-	randomx_vm *myMachine = randomx_create_vm((randomx_flags)(RANDOMX_FLAG_FULL_MEM | RANDOMX_FLAG_JIT | RANDOMX_FLAG_HARD_AES | RANDOMX_FLAG_LARGE_PAGES), nullptr, myDataset);
+	randomx_vm *myMachine = randomx_create_vm(flags, nullptr, myDataset);
 	if (myMachine == nullptr) {
 		std::cout << "Failed to create a virtual machine" << std::endl;
 		return 1;
@@ -40,7 +43,7 @@ int main() {
 	randomx_release_dataset(myDataset);
 
 	for (unsigned i = 0; i < RANDOMX_HASH_SIZE; ++i)
-		std::cout << std::hex << ((int)hash[i] & 0xff);
+		std::cout << std::hex << std::setw(2) << std::setfill('0') << ((int)hash[i] & 0xff);
 
 	std::cout << std::endl;
 

--- a/src/tests/benchmark.cpp
+++ b/src/tests/benchmark.cpp
@@ -203,12 +203,14 @@ int main(int argc, char** argv) {
 		flags |= RANDOMX_FLAG_SECURE;
 	}
 
-	if (flags & RANDOMX_FLAG_ARGON2_SSSE3) {
-		std::cout << " - Argon2 implementation: SSSE3" << std::endl;
-	}
-
 	if (flags & RANDOMX_FLAG_ARGON2_AVX2) {
 		std::cout << " - Argon2 implementation: AVX2" << std::endl;
+	}
+	else if (flags & RANDOMX_FLAG_ARGON2_SSSE3) {
+		std::cout << " - Argon2 implementation: SSSE3" << std::endl;
+	}
+	else {
+		std::cout << " - Argon2 implementation: reference" << std::endl;
 	}
 
 	if (flags & RANDOMX_FLAG_FULL_MEM) {
@@ -253,7 +255,9 @@ int main(int argc, char** argv) {
 	std::cout << " ..." << std::endl;
 
 	try {
-		randomx::selectArgonImpl(flags); //just to check if flags are valid
+		if (nullptr == randomx::selectArgonImpl(flags)) {
+			throw std::runtime_error("Unsupported Argon2 implementation");
+		}
 		if ((flags & RANDOMX_FLAG_JIT) && !RANDOMX_HAVE_COMPILER) {
 			throw std::runtime_error("JIT compilation is not supported on this platform. Try without --jit");
 		}

--- a/vcxproj/randomx.vcxproj
+++ b/vcxproj/randomx.vcxproj
@@ -114,7 +114,6 @@
       <ConformanceMode>true</ConformanceMode>
       <AssemblerOutput>AssemblyCode</AssemblerOutput>
       <PreprocessorDefinitions>_MBCS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -132,7 +131,9 @@ SET ERRORLEVEL = 0</Command>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\src\allocator.cpp" />
-    <ClCompile Include="..\src\argon2_avx2.c" />
+    <ClCompile Include="..\src\argon2_avx2.c">
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+    </ClCompile>
     <ClCompile Include="..\src\argon2_core.c" />
     <ClCompile Include="..\src\argon2_ref.c" />
     <ClCompile Include="..\src\argon2_ssse3.c" />
@@ -140,6 +141,7 @@ SET ERRORLEVEL = 0</Command>
     <ClCompile Include="..\src\blake2_generator.cpp" />
     <ClCompile Include="..\src\blake2\blake2b.c" />
     <ClCompile Include="..\src\bytecode_machine.cpp" />
+    <ClCompile Include="..\src\cpu.cpp" />
     <ClCompile Include="..\src\vm_compiled_light.cpp" />
     <ClCompile Include="..\src\vm_compiled.cpp" />
     <ClCompile Include="..\src\dataset.cpp" />
@@ -173,6 +175,7 @@ SET ERRORLEVEL = 0</Command>
     <ClInclude Include="..\src\blake2_generator.hpp" />
     <ClInclude Include="..\src\bytecode_machine.hpp" />
     <ClInclude Include="..\src\common.hpp" />
+    <ClInclude Include="..\src\cpu.hpp" />
     <ClInclude Include="..\src\jit_compiler.hpp" />
     <ClInclude Include="..\src\jit_compiler_a64.hpp" />
     <ClInclude Include="..\src\jit_compiler_fallback.hpp" />

--- a/vcxproj/randomx.vcxproj.filters
+++ b/vcxproj/randomx.vcxproj.filters
@@ -87,6 +87,9 @@
     <ClCompile Include="..\src\argon2_ssse3.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\cpu.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\argon2.h">
@@ -195,6 +198,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\src\blake2\blamka-round-ssse3.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Can autodetect AES, SSSE3 and AVX2 and sets the JIT flag if supported.

Usage:
```c
randomx_flags flags = randomx_get_flags();
randomx_cache *myCache = randomx_alloc_cache(flags);
randomx_init_cache(myCache, &myKey, sizeof myKey);
randomx_vm *myMachine = randomx_create_vm(flags, myCache, NULL);
``` 

AES detection on ARM64 needs testing.