### PR TITLE
Fixed mmap on OpenBSD

### DIFF
--- a/src/virtual_memory.cpp
+++ b/src/virtual_memory.cpp
@@ -141,6 +141,8 @@ void* allocLargePagesMemory(std::size_t bytes) {
 	mem = mmap(nullptr, bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, VM_FLAGS_SUPERPAGE_SIZE_2MB, 0);
 #elif defined(__FreeBSD__)
 	mem = mmap(nullptr, bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_ALIGNED_SUPER, -1, 0);
+#elif defined(__OpenBSD__)
+	mem = MAP_FAILED; // OpenBSD does not support huge pages
 #else
 	mem = mmap(nullptr, bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_POPULATE, -1, 0);
 #endif


### PR DESCRIPTION
OpenBSD's mmap does not support `MAP_HUGETLB` and `MAP_POPULATE`.