### PR TITLE
Fixed tests on OpenBSD

### DIFF
--- a/src/randomx.cpp
+++ b/src/randomx.cpp
@@ -42,6 +42,11 @@ extern "C" {
 	randomx_flags randomx_get_flags() {
 		randomx_flags flags = RANDOMX_HAVE_COMPILER ? RANDOMX_FLAG_JIT : RANDOMX_FLAG_DEFAULT;
 		randomx::Cpu cpu;
+#ifdef __OpenBSD__
+		if (flags == RANDOMX_FLAG_JIT) {
+			flags |= RANDOMX_FLAG_SECURE;
+		}
+#endif
 		if (HAVE_AES && cpu.hasAes()) {
 			flags |= RANDOMX_FLAG_HARD_AES;
 		}

--- a/src/randomx.h
+++ b/src/randomx.h
@@ -83,6 +83,7 @@ extern "C" {
  *            RANDOMX_FLAG_FULL_MEM
  *            RANDOMX_FLAG_SECURE
  *         These flags must be added manually if desired.
+ *         On OpenBSD RANDOMX_FLAG_SECURE is enabled by default in JIT mode as W^X is enforced by the OS.
  */
 RANDOMX_EXPORT randomx_flags randomx_get_flags(void);
 

--- a/src/tests/affinity.cpp
+++ b/src/tests/affinity.cpp
@@ -65,7 +65,7 @@ set_thread_affinity(std::thread::native_handle_type thread,
             (thread_policy_t)&policy, 1);
 #elif defined(_WIN32) || defined(__CYGWIN__)
     rc = SetThreadAffinityMask(reinterpret_cast<HANDLE>(thread), 1ULL << cpuid) == 0 ? -2 : 0;
-#else
+#elif !defined(__OpenBSD__)
     cpu_set_t cs;
     CPU_ZERO(&cs);
     CPU_SET(cpuid, &cs);

--- a/src/tests/benchmark.cpp
+++ b/src/tests/benchmark.cpp
@@ -190,6 +190,9 @@ int main(int argc, char** argv) {
 		}
 		if (jit) {
 			flags |= RANDOMX_FLAG_JIT;
+#ifdef __OpenBSD__
+			flags |= RANDOMX_FLAG_SECURE;
+#endif
 		}
 	}
 
@@ -199,9 +202,11 @@ int main(int argc, char** argv) {
 	if (miningMode) {
 		flags |= RANDOMX_FLAG_FULL_MEM;
 	}
+#ifndef __OpenBSD__
 	if (secure) {
 		flags |= RANDOMX_FLAG_SECURE;
 	}
+#endif
 
 	if (flags & RANDOMX_FLAG_ARGON2_AVX2) {
 		std::cout << " - Argon2 implementation: AVX2" << std::endl;

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -143,7 +143,11 @@ int main() {
 		randomx::JitCompiler jit;
 		jit.generateSuperscalarHash(cache->programs, cache->reciprocalCache);
 		jit.generateDatasetInitCode();
+#ifdef __OpenBSD__
+		jit.enableExecution();
+#else
 		jit.enableAll();
+#endif
 		uint64_t datasetItem[8];
 		jit.getDatasetInitFunc()(cache, (uint8_t*)&datasetItem, 0, 1);
 		assert(datasetItem[0] == 0x680588a85ae222db);
@@ -950,7 +954,11 @@ int main() {
 		assert(ibc.memMask == randomx::ScratchpadL3Mask);
 	});
 
+#ifdef __OpenBSD__
+	vm = randomx_create_vm(RANDOMX_FLAG_DEFAULT | RANDOMX_FLAG_SECURE, cache, nullptr);
+#else
 	vm = randomx_create_vm(RANDOMX_FLAG_DEFAULT, cache, nullptr);
+#endif
 
 	auto test_a = [&] {
 		char hash[RANDOMX_HASH_SIZE];
@@ -1001,7 +1009,11 @@ int main() {
 		vm = nullptr;
 		cache = randomx_alloc_cache(RANDOMX_FLAG_JIT);
 		initCache("test key 000");
-		vm = randomx_create_vm(RANDOMX_FLAG_JIT, cache, nullptr);
+#ifdef __OpenBSD__
+		vm = randomx_create_vm(RANDOMX_FLAG_DEFAULT | RANDOMX_FLAG_SECURE, cache, nullptr);
+#else
+		vm = randomx_create_vm(RANDOMX_FLAG_DEFAULT, cache, nullptr);
+#endif
 	}
 
 	runTest("Hash test 2a (compiler)", RANDOMX_HAVE_COMPILER && stringsEqual(RANDOMX_ARGON_SALT, "RandomX\x03"), test_a);


### PR DESCRIPTION
Since OpenBSD 6.0 W^X is enforced.
Added `RANDOMX_FLAG_SECURE` in tests and benchmarks.

Excluded `cpu_set_t` since it is not defined on OpenBSD.