### PR TITLE
virtual_memory: add MAP_JIT on macOS

### DIFF
--- a/src/virtual_memory.cpp
+++ b/src/virtual_memory.cpp
@@ -99,7 +99,17 @@ void* allocMemoryPages(std::size_t bytes) {
 	#else
 		#define RESERVED_FLAGS 0
 	#endif
-	mem = mmap(nullptr, bytes, PAGE_READWRITE | RESERVED_FLAGS, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+	#ifdef __APPLE__
+		#include <TargetConditionals.h>
+		#ifdef TARGET_OS_OSX
+			#define MEXTRA MAP_JIT
+		#else
+			#define MEXTRA 0
+		#endif
+	#else
+		#define MEXTRA 0
+	#endif
+	mem = mmap(nullptr, bytes, PAGE_READWRITE | RESERVED_FLAGS, MAP_ANONYMOUS | MAP_PRIVATE | MEXTRA, -1, 0);
 	if (mem == MAP_FAILED)
 		throw std::runtime_error("allocMemoryPages - mmap failed");
 #endif


### PR DESCRIPTION
This change makes it possible to enable hardened runtime with `com.apple.security.cs.allow-jit` key instead of `com.apple.security.cs.allow-unsigned-executable-memory`.

A bit ugly with nested `#ifdef`. Apparently there is a crashing issue on macOS 10.13 or lower but I was not able to reproduce it on macOS 10.12: https://github.com/herumi/xbyak/pull/84#issuecomment-562442380

Also does this make issues on iOS or does it use interpreter mode anyway? 