### PR TITLE
replace hardcoded literal with its appropriate symbol

### DIFF
--- a/src/jit_compiler_x86.cpp
+++ b/src/jit_compiler_x86.cpp
@@ -295,7 +295,7 @@ namespace randomx {
 
 	void JitCompilerX86::generateProgramPrologue(Program& prog, ProgramConfiguration& pcfg) {
 		instructionOffsets.clear();
-		for (unsigned i = 0; i < 8; ++i) {
+		for (unsigned i = 0; i < RegistersCount; ++i) {
 			registerUsage[i] = -1;
 		}
 


### PR DESCRIPTION
I believe his hardcoded "8" should actually be RegistersCount, just in case anyone tries to create a variant with more/fewer registers.