### PR TITLE
Fix potential use-after-free when reallocating cache

### DIFF
--- a/src/randomx.cpp
+++ b/src/randomx.cpp
@@ -329,7 +329,7 @@ extern "C" {
 	void randomx_vm_set_cache(randomx_vm *machine, randomx_cache* cache) {
 		assert(machine != nullptr);
 		assert(cache != nullptr && cache->isInitialized());
-		if (machine->cacheKey != cache->cacheKey) {
+		if (machine->cacheKey != cache->cacheKey || machine->getMemory() != cache->memory) {
 			machine->setCache(cache);
 			machine->cacheKey = cache->cacheKey;
 		}

--- a/src/virtual_machine.hpp
+++ b/src/virtual_machine.hpp
@@ -54,6 +54,9 @@ public:
 	{
 		return program;
 	}
+	const uint8_t* getMemory() const {
+		return mem.memory;
+	}
 protected:
 	void initialize();
 	alignas(64) randomx::Program program;


### PR DESCRIPTION
Happens when the cache is reallocated and intialized with the same key. The VM would keep the old pointer.

This fixes random crashes in test 91.