### PR TITLE
__cpuidex: explicit MSVC check, fix MinGW GCC 5.3 cross-compilation

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if defined(_M_X64) || defined(__x86_64__)
 	#define HAVE_CPUID
-	#ifdef _WIN32
+	#if defined(_MSC_VER)
 		#include <intrin.h>
 		#define cpuid(info, x) __cpuidex(info, x, 0)
 	#else //GCC


### PR DESCRIPTION
MinGW GCC 5.3 defines `_WIN32` when cross-compiling to Windows from Linux, 

BTW, `__cpuidex` intrinsic has been added to GCC a few weeks ago (most probably will be in GCC 11 release). Thus the ifdef would need a tweak in foreseeable future.