### PR TITLE
[POC] make build work on a m1 chipset mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,12 +148,10 @@ endif()
 
 # ARMv8
 if(ARM_ID STREQUAL "aarch64" OR ARM_ID STREQUAL "arm64" OR ARM_ID STREQUAL "armv8-a")
+  enable_language(ASM)
   list(APPEND randomx_sources
     src/jit_compiler_a64_static.S
     src/jit_compiler_a64.cpp)
-  # cheat because cmake and ccache hate each other
-  set_property(SOURCE src/jit_compiler_a64_static.S PROPERTY LANGUAGE C)
-  set_property(SOURCE src/jit_compiler_x86_static.S PROPERTY XCODE_EXPLICIT_FILE_TYPE sourcecode.asm)
 
   # not sure if this check is needed
   include(CheckIncludeFile)


### PR DESCRIPTION
While attempting to test this project on m1 chip'd apple device, I noticed an ASM file was being interpreted as the wrong filetype, causing the build to fail with:

![image](https://user-images.githubusercontent.com/1377/99879845-c1d1b180-2bcc-11eb-98cf-45cfaf3da004.png)

[@hyc pointed out that](https://twitter.com/hyc_symas/status/1330111293269938179?s=20) that it may be the lack of `enable_language(ASM)` in the CMakeList.txt.

This PR now does allow the project to build correctly on my device, unfortunately the compiler test currently fail:

![image](https://user-images.githubusercontent.com/1377/99879991-d9f60080-2bcd-11eb-8bcb-89a794e85f73.png)

I'll gladly make changes to this PR as needed, and also can gladly test other stuff on apples m1 chipset.
