### PR TITLE
remove unnecessary first-load initialization code

### DIFF
--- a/src/jit_compiler_x86.cpp
+++ b/src/jit_compiler_x86.cpp
@@ -299,10 +299,6 @@ namespace randomx {
 			registerUsage[i] = -1;
 		}
 
-		codePos = ((uint8_t*)randomx_program_prologue_first_load) - ((uint8_t*)randomx_program_prologue);
-		code[codePos + sizeof(REX_XOR_RAX_R64)] = 0xc0 + pcfg.readReg0;
-		code[codePos + sizeof(REX_XOR_RAX_R64) * 2 + 1] = 0xc0 + pcfg.readReg1;
-
 		codePos = prologueSize;
 		memcpy(code + codePos - 48, &pcfg.eMask, sizeof(pcfg.eMask));
 		memcpy(code + codePos, codeLoopLoad, loopLoadSize);

--- a/src/jit_compiler_x86_static.S
+++ b/src/jit_compiler_x86_static.S
@@ -40,7 +40,6 @@
 .global DECL(randomx_prefetch_scratchpad)
 .global DECL(randomx_prefetch_scratchpad_end)
 .global DECL(randomx_program_prologue)
-.global DECL(randomx_program_prologue_first_load)
 .global DECL(randomx_program_loop_begin)
 .global DECL(randomx_program_loop_load)
 .global DECL(randomx_program_start)
@@ -88,10 +87,6 @@ DECL(randomx_program_prologue):
 	movapd xmm13, xmmword ptr [mantissaMask+rip]
 	movapd xmm14, xmmword ptr [exp240+rip]
 	movapd xmm15, xmmword ptr [scaleMask+rip]
-
-DECL(randomx_program_prologue_first_load):
-	xor rax, r8
-	xor rax, r8
 	mov rdx, rax
 	and eax, RANDOMX_SCRATCHPAD_MASK
 	ror rdx, 32

--- a/src/jit_compiler_x86_static.asm
+++ b/src/jit_compiler_x86_static.asm
@@ -31,7 +31,6 @@ _RANDOMX_JITX86_STATIC SEGMENT PAGE READ EXECUTE
 PUBLIC randomx_prefetch_scratchpad
 PUBLIC randomx_prefetch_scratchpad_end
 PUBLIC randomx_program_prologue
-PUBLIC randomx_program_prologue_first_load
 PUBLIC randomx_program_loop_begin
 PUBLIC randomx_program_loop_load
 PUBLIC randomx_program_start
@@ -75,17 +74,12 @@ randomx_program_prologue PROC
 	movapd xmm13, xmmword ptr [mantissaMask]
 	movapd xmm14, xmmword ptr [exp240]
 	movapd xmm15, xmmword ptr [scaleMask]
-randomx_program_prologue ENDP
-
-randomx_program_prologue_first_load PROC
-	xor rax, r8
-	xor rax, r8
 	mov rdx, rax
 	and eax, RANDOMX_SCRATCHPAD_MASK
 	ror rdx, 32
 	and edx, RANDOMX_SCRATCHPAD_MASK
 	jmp randomx_program_loop_begin
-randomx_program_prologue_first_load ENDP
+randomx_program_prologue ENDP
 
 ALIGN 64
 	include asm/program_xmm_constants.inc

--- a/src/jit_compiler_x86_static.hpp
+++ b/src/jit_compiler_x86_static.hpp
@@ -32,7 +32,6 @@ extern "C" {
 	void randomx_prefetch_scratchpad();
 	void randomx_prefetch_scratchpad_end();
 	void randomx_program_prologue();
-	void randomx_program_prologue_first_load();
 	void randomx_program_loop_begin();
 	void randomx_program_loop_load();
 	void randomx_program_start();


### PR DESCRIPTION
Because all registers are initialized to 0 at this point, there's no need to XOR them at initialization time.
