### PR TITLE
Faster W^X policy for apple silicon macs

### DIFF
--- a/src/virtual_memory.cpp
+++ b/src/virtual_memory.cpp
@@ -35,6 +35,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #else
 #ifdef __APPLE__
 #include <mach/vm_statistics.h>
+#include <TargetConditionals.h>
+# if defined(__aarch64__) && TARGET_OS_OSX
+# define USE_PTHREAD_JIT_WP	1
+# include <pthread.h>
+# endif
 #endif
 #include <sys/types.h>
 #include <sys/mman.h>
@@ -109,9 +114,17 @@ void* allocMemoryPages(std::size_t bytes) {
 	#else
 		#define MEXTRA 0
 	#endif
-	mem = mmap(nullptr, bytes, PAGE_READWRITE | RESERVED_FLAGS, MAP_ANONYMOUS | MAP_PRIVATE | MEXTRA, -1, 0);
+	#ifdef USE_PTHREAD_JIT_WP
+		#define PEXTRA	PROT_EXEC
+	#else
+		#define PEXTRA	0
+	#endif
+	mem = mmap(nullptr, bytes, PAGE_READWRITE | RESERVED_FLAGS | PEXTRA, MAP_ANONYMOUS | MAP_PRIVATE | MEXTRA, -1, 0);
 	if (mem == MAP_FAILED)
 		throw std::runtime_error("allocMemoryPages - mmap failed");
+#ifdef USE_PTHREAD_JIT_WP
+	pthread_jit_write_protect_np(false);
+#endif
 #endif
 	return mem;
 }
@@ -129,11 +142,19 @@ static inline void pageProtect(void* ptr, std::size_t bytes, int rules) {
 }
 
 void setPagesRW(void* ptr, std::size_t bytes) {
+#ifdef USE_PTHREAD_JIT_WP
+	pthread_jit_write_protect_np(false);
+#else
 	pageProtect(ptr, bytes, PAGE_READWRITE);
+#endif
 }
 
 void setPagesRX(void* ptr, std::size_t bytes) {
+#ifdef USE_PTHREAD_JIT_WP
+	pthread_jit_write_protect_np(true);
+#else
 	pageProtect(ptr, bytes, PAGE_EXECUTE_READ);
+#endif
 }
 
 void setPagesRWX(void* ptr, std::size_t bytes) {


### PR DESCRIPTION
This is a fixed version of #199. Should also use #198 with this.

With only #198 I get 2279H/s with 8 threads. With this PR added, I get 2328H/s. No improvement with only 1 thread.