### PR TITLE
Fix absolute address references

### DIFF
--- a/src/jit_compiler_a64_static.S
+++ b/src/jit_compiler_a64_static.S
@@ -333,6 +333,7 @@ DECL(randomx_program_aarch64_cacheline_align_mask2):
 	add	x10, x10, x1
 
 DECL(randomx_program_aarch64_xor_with_dataset_line):
+rx_program_xor_with_dataset_line:
 	# xor integer registers with dataset data
 	ldp	x18, x19, [x10]
 	eor	x4, x4, x18
@@ -431,14 +432,14 @@ DECL(randomx_program_aarch64_light_dataset_offset):
 	add	x2, x2, 0
 	add	x2, x2, 0
 
-	bl	DECL(randomx_calc_dataset_item_aarch64)
+	bl	rx_calc_dataset_item
 
 	mov	x10, sp
 	ldp	x0, x1, [sp, 64]
 	ldp	x2, x30, [sp, 80]
 	add	sp, sp, 96
 
-	b	DECL(randomx_program_aarch64_xor_with_dataset_line)
+	b	rx_program_xor_with_dataset_line
 
 
 
@@ -457,7 +458,7 @@ DECL(randomx_init_dataset_aarch64):
 	ldr	x0, [x0]
 
 DECL(randomx_init_dataset_aarch64_main_loop):
-	bl	DECL(randomx_calc_dataset_item_aarch64)
+	bl	rx_calc_dataset_item
 	add	x1, x1, 64
 	add	x2, x2, 1
 	cmp	x2, x3
@@ -487,6 +488,7 @@ DECL(randomx_init_dataset_aarch64_end):
 # x13 -> temporary
 
 DECL(randomx_calc_dataset_item_aarch64):
+rx_calc_dataset_item:
 	sub	sp, sp, 112
 	stp	x0, x1, [sp]
 	stp	x2, x3, [sp, 16]
@@ -533,7 +535,7 @@ DECL(randomx_calc_dataset_item_aarch64):
 	ldr	x12, superscalarAdd7
 	eor	x7, x0, x12
 
-	b	DECL(randomx_calc_dataset_item_aarch64_prefetch)
+	b	rx_calc_dataset_item_prefetch
 
 superscalarMul0: .quad 6364136223846793005
 superscalarAdd1: .quad 9298411001130361340
@@ -547,6 +549,7 @@ superscalarAdd7: .quad 9549104520008361294
 # Prefetch -> SuperScalar hash -> Mix will be repeated N times
 
 DECL(randomx_calc_dataset_item_aarch64_prefetch):
+rx_calc_dataset_item_prefetch:
 	# Actual mask will be inserted by JIT compiler
 	and	x11, x10, 1
 	add	x11, x8, x11, lsl 6

--- a/src/jit_compiler_x86_static.S
+++ b/src/jit_compiler_x86_static.S
@@ -91,13 +91,14 @@ DECL(randomx_program_prologue):
 	and eax, RANDOMX_SCRATCHPAD_MASK
 	ror rdx, 32
 	and edx, RANDOMX_SCRATCHPAD_MASK
-	jmp DECL(randomx_program_loop_begin)
+	jmp rx_program_loop_begin
 
 .balign 64
 	#include "asm/program_xmm_constants.inc"
 
 .balign 64
 DECL(randomx_program_loop_begin):
+rx_program_loop_begin:
 	nop
 
 DECL(randomx_program_loop_load):
@@ -123,6 +124,7 @@ DECL(randomx_program_loop_end):
 
 .balign 64
 DECL(randomx_dataset_init):
+rx_dataset_init:
 	push rbx
 	push rbp
 	push r12
@@ -146,7 +148,7 @@ init_block_loop:
 	prefetchw byte ptr [rsi]
 	mov rbx, rbp
 	.byte 232 ;# 0xE8 = call
-	.int SUPERSCALAR_OFFSET - (call_offset - DECL(randomx_dataset_init))
+	.int SUPERSCALAR_OFFSET - (call_offset - rx_dataset_init)
 call_offset:
 	mov qword ptr [rsi+0], r8
 	mov qword ptr [rsi+8], r9
@@ -211,13 +213,14 @@ DECL(randomx_sshash_init):
 	xor r14, r8
 	mov r15, qword ptr [r7_add+rip]
 	xor r15, r8
-	jmp DECL(randomx_program_end)
+	jmp rx_program_end
 
 .balign 64
 	#include "asm/program_sshash_constants.inc"
 
 .balign 64
 DECL(randomx_program_end):
+rx_program_end:
 	nop
 
 DECL(randomx_reciprocal_fast):

--- a/src/jit_compiler_x86_static.asm
+++ b/src/jit_compiler_x86_static.asm
@@ -78,7 +78,7 @@ randomx_program_prologue PROC
 	and eax, RANDOMX_SCRATCHPAD_MASK
 	ror rdx, 32
 	and edx, RANDOMX_SCRATCHPAD_MASK
-	jmp randomx_program_loop_begin
+	jmp rx_program_loop_begin
 randomx_program_prologue ENDP
 
 ALIGN 64
@@ -86,6 +86,7 @@ ALIGN 64
 
 ALIGN 64
 randomx_program_loop_begin PROC
+rx_program_loop_begin::
 	nop
 randomx_program_loop_begin ENDP
 
@@ -199,7 +200,7 @@ randomx_sshash_init PROC
 	xor r14, r8
 	mov r15, qword ptr [r7_add]
 	xor r15, r8
-	jmp randomx_program_end
+	jmp rx_program_end
 randomx_sshash_init ENDP
 
 ALIGN 64
@@ -207,6 +208,7 @@ ALIGN 64
 
 ALIGN 64
 randomx_program_end PROC
+rx_program_end::
 	nop
 randomx_program_end ENDP
 


### PR DESCRIPTION
Use local symbols instead of global symbols, to prevent problems
with dynamic linker.

Was causing reproducible crashes in monero core_tests.
The .S patches have been tested on ARM and x86-64 Linux. The corresponding .asm patches are untested and need review, perhaps they're not needed.

The crashes were only in debug builds; they use dynamically linked libraries. This bug only hits when librandomx is a shared library.