### PR TITLE
Fix W^X policy for apple portability

### DIFF
--- a/src/virtual_memory.cpp
+++ b/src/virtual_memory.cpp
@@ -142,6 +142,8 @@ void setPagesRW(void* ptr, std::size_t bytes) {
 	&& MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0
 	if (__builtin_available(macOS 11.0, *)) {
 		pthread_jit_write_protect_np(false);
+	} else {
+		pageProtect(ptr, bytes, PAGE_READWRITE);
 	}
 #else
 	pageProtect(ptr, bytes, PAGE_READWRITE);
@@ -153,6 +155,8 @@ void setPagesRX(void* ptr, std::size_t bytes) {
 	&& MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0
 	if (__builtin_available(macOS 11.0, *)) {
 		pthread_jit_write_protect_np(true);
+	} else {
+		pageProtect(ptr, bytes, PAGE_EXECUTE_READ);
 	}
 #else
 	pageProtect(ptr, bytes, PAGE_EXECUTE_READ);

--- a/src/virtual_memory.cpp
+++ b/src/virtual_memory.cpp
@@ -36,12 +36,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef __APPLE__
 #include <mach/vm_statistics.h>
 #include <TargetConditionals.h>
+#include <AvailabilityMacros.h>
 # if TARGET_OS_OSX
-#  if TARGET_CPU_ARM64
-#   define USE_PTHREAD_JIT_WP	1
-#  else
-#   undef USE_PTHREAD_JIT_WP
-#  endif
+#  define USE_PTHREAD_JIT_WP	1
 #  include <pthread.h>
 # endif
 #endif
@@ -118,8 +115,11 @@ void* allocMemoryPages(std::size_t bytes) {
 	mem = mmap(nullptr, bytes, PAGE_READWRITE | RESERVED_FLAGS | PEXTRA, MAP_ANONYMOUS | MAP_PRIVATE | MEXTRA, -1, 0);
 	if (mem == MAP_FAILED)
 		throw std::runtime_error("allocMemoryPages - mmap failed");
-#ifdef USE_PTHREAD_JIT_WP
-	pthread_jit_write_protect_np(false);
+#if defined(USE_PTHREAD_JIT_WP) && defined(MAC_OS_VERSION_11_0) \
+	&& MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0
+	if (__builtin_available(macOS 11.0, *)) {
+		pthread_jit_write_protect_np(false);
+	}
 #endif
 #endif
 	return mem;
@@ -138,16 +138,22 @@ static inline void pageProtect(void* ptr, std::size_t bytes, int rules) {
 }
 
 void setPagesRW(void* ptr, std::size_t bytes) {
-#ifdef USE_PTHREAD_JIT_WP
-	pthread_jit_write_protect_np(false);
+#if defined(USE_PTHREAD_JIT_WP) && defined(MAC_OS_VERSION_11_0) \
+	&& MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0
+	if (__builtin_available(macOS 11.0, *)) {
+		pthread_jit_write_protect_np(false);
+	}
 #else
 	pageProtect(ptr, bytes, PAGE_READWRITE);
 #endif
 }
 
 void setPagesRX(void* ptr, std::size_t bytes) {
-#ifdef USE_PTHREAD_JIT_WP
-	pthread_jit_write_protect_np(true);
+#if defined(USE_PTHREAD_JIT_WP) && defined(MAC_OS_VERSION_11_0) \
+	&& MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0
+	if (__builtin_available(macOS 11.0, *)) {
+		pthread_jit_write_protect_np(true);
+	}
 #else
 	pageProtect(ptr, bytes, PAGE_EXECUTE_READ);
 #endif

--- a/src/virtual_memory.cpp
+++ b/src/virtual_memory.cpp
@@ -36,9 +36,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef __APPLE__
 #include <mach/vm_statistics.h>
 #include <TargetConditionals.h>
-# ifdef TARGET_OS_OSX
-# define USE_PTHREAD_JIT_WP	1
-# include <pthread.h>
+# if TARGET_OS_OSX
+#  if TARGET_CPU_ARM64
+#   define USE_PTHREAD_JIT_WP	1
+#  else
+#   undef USE_PTHREAD_JIT_WP
+#  endif
+#  include <pthread.h>
 # endif
 #endif
 #include <sys/types.h>


### PR DESCRIPTION
`pthread_jit_write_protect_np` undefined on at least Mojave (10.14.6, x86_64).