### PR TITLE
RandomX benchmark 1.1.11

### DIFF
--- a/src/tests/benchmark.cpp
+++ b/src/tests/benchmark.cpp
@@ -175,7 +175,7 @@ int main(int argc, char** argv) {
 
 	store32(&seed, seedValue);
 
-	std::cout << "RandomX benchmark v1.1.8" << std::endl;
+	std::cout << "RandomX benchmark v1.1.11" << std::endl;
 
 	if (help) {
 		printUsage(argv[0]);


### PR DESCRIPTION
We forgot to bump the version number for the last two tags.