### PR TITLE
Pr nyuu a64 c1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ x64/
 Release/
 Debug/
 build/
+.kdev4
+RandomX-tk1.pbg.su.kdev4
+sekrit/

--- a/src/jit_compiler_a64.hpp
+++ b/src/jit_compiler_a64.hpp
@@ -40,6 +40,7 @@ namespace randomx {
 	class Program;
 	struct ProgramConfiguration;
 	class SuperscalarProgram;
+	class JitCompilerA64;
 	class Instruction;
 
 	typedef void(JitCompilerA64::*InstructionGeneratorA64)(Instruction&, uint32_t&);


### PR DESCRIPTION
Hi,

while trying to understand the code and working on it, i noticed that in the 'src/jit_compiler_a64.hpp ' file, my markup did not work properly because according to KDevelop, the were several uses of undeclared 'class JitCompilerA64' references.

I just added the code at line 43 next to the other declarations (as it is done in the 'src/jit_compiler_x86.hpp') and the markup works now and i get no errors in my IDE anymore.
Not sure if this really is a code error or just a very sensitive IDE as i am new to KDevelop ^^"