### PR TITLE
Fixed cache->jit memory leak

### DIFF
--- a/src/randomx.cpp
+++ b/src/randomx.cpp
@@ -134,9 +134,7 @@ extern "C" {
 
 	void randomx_release_cache(randomx_cache* cache) {
 		assert(cache != nullptr);
-		if (cache->memory != nullptr) {
-			cache->dealloc(cache);
-		}
+		cache->dealloc(cache);
 		delete cache;
 	}
 


### PR DESCRIPTION
1. `cache->jit = new randomx::JitCompiler();` - succeeds
2. `cache->memory = (uint8_t*)randomx::LargePageAllocator::allocMemory(randomx::CacheSize);` - fails
3. `if (cache && cache->memory == nullptr) randomx_release_cache(cache);` is executed
4. randomx_release_cache checks `if (cache->memory != nullptr)` and does nothing
5. cache->jit stays allocated