### PR TITLE
RandomX v2 virtual machine changes

### DIFF
--- a/src/asm/program_loop_store.inc
+++ b/src/asm/program_loop_store.inc
@@ -8,10 +8,22 @@
 	mov qword ptr [rcx+48], r14
 	mov qword ptr [rcx+56], r15
 	pop rcx
-	xorpd xmm0, xmm4
-	xorpd xmm1, xmm5
-	xorpd xmm2, xmm6
-	xorpd xmm3, xmm7
+	aesenc xmm0, xmm4
+	aesdec xmm1, xmm4
+	aesenc xmm2, xmm4
+	aesdec xmm3, xmm4
+	aesenc xmm0, xmm5
+	aesdec xmm1, xmm5
+	aesenc xmm2, xmm5
+	aesdec xmm3, xmm5
+	aesenc xmm0, xmm6
+	aesdec xmm1, xmm6
+	aesenc xmm2, xmm6
+	aesdec xmm3, xmm6
+	aesenc xmm0, xmm7
+	aesdec xmm1, xmm7
+	aesenc xmm2, xmm7
+	aesdec xmm3, xmm7
 	movapd xmmword ptr [rcx+0], xmm0
 	movapd xmmword ptr [rcx+16], xmm1
 	movapd xmmword ptr [rcx+32], xmm2

--- a/src/bytecode_machine.hpp
+++ b/src/bytecode_machine.hpp
@@ -259,7 +259,10 @@ namespace randomx {
 		}
 
 		static void exe_CFROUND(RANDOMX_EXE_ARGS) {
-			rx_set_rounding_mode(rotr(*ibc.isrc, ibc.imm) % 4);
+			uint64_t isrc = rotr(*ibc.isrc, ibc.imm);
+			if ((isrc & 60) == 0) {
+				rx_set_rounding_mode(isrc % 4);
+			}
 		}
 
 		static void exe_ISTORE(RANDOMX_EXE_ARGS) {

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -31,6 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdint>
 #include <iostream>
 #include <climits>
+#include <array>
 #include "blake2/endian.h"
 #include "configuration.h"
 #include "randomx.h"
@@ -114,10 +115,14 @@ namespace randomx {
 #endif
 #endif
 
+	class SuperscalarProgram;
+	using SuperscalarProgramList = std::array<SuperscalarProgram, RANDOMX_CACHE_ACCESSES>;
+
 #if defined(_M_X64) || defined(__x86_64__)
 	#define RANDOMX_HAVE_COMPILER 1
+	template<randomx_flags vmFlags>
 	class JitCompilerX86;
-	using JitCompiler = JitCompilerX86;
+	using JitCompiler = JitCompilerX86<RANDOMX_FLAG_V2>;
 #elif defined(__aarch64__)
 	#define RANDOMX_HAVE_COMPILER 1
 	class JitCompilerA64;

--- a/src/dataset.hpp
+++ b/src/dataset.hpp
@@ -49,7 +49,7 @@ struct randomx_cache {
 	randomx::JitCompiler* jit;
 	randomx::CacheInitializeFunc* initialize;
 	randomx::DatasetInitFunc* datasetInit;
-	randomx::SuperscalarProgram programs[RANDOMX_CACHE_ACCESSES];
+	randomx::SuperscalarProgramList programs;
 	std::vector<uint64_t> reciprocalCache;
 	std::string cacheKey;
 	randomx_argon2_impl* argonImpl;

--- a/src/intrin_portable.h
+++ b/src/intrin_portable.h
@@ -124,6 +124,8 @@ FORCE_INLINE rx_vec_f128 rx_set1_vec_f128(uint64_t x) {
 	return _mm_castsi128_pd(_mm_set1_epi64x(x));
 }
 
+#define rx_cast_vec_i2f _mm_castsi128_pd
+#define rx_cast_vec_f2i _mm_castpd_si128
 #define rx_xor_vec_f128 _mm_xor_pd
 #define rx_and_vec_f128 _mm_and_pd
 #define rx_or_vec_f128 _mm_or_pd
@@ -623,6 +625,16 @@ FORCE_INLINE rx_vec_f128 rx_set1_vec_f128(uint64_t x) {
 	v.i.u64[0] = x;
 	v.i.u64[1] = x;
 	return v;
+}
+
+FORCE_INLINE rx_vec_f128 rx_cast_vec_i2f(rx_vec_i128 a) {
+	rx_vec_f128 x;
+	x.i = a;
+	return x;
+}
+
+FORCE_INLINE rx_vec_i128 rx_cast_vec_f2i(rx_vec_f128 a) {
+	return a.i;
 }
 
 FORCE_INLINE rx_vec_f128 rx_xor_vec_f128(rx_vec_f128 a, rx_vec_f128 b) {

--- a/src/jit_compiler_fallback.hpp
+++ b/src/jit_compiler_fallback.hpp
@@ -50,8 +50,8 @@ namespace randomx {
 		void generateProgramLight(Program&, ProgramConfiguration&, uint32_t) {
 
 		}
-		template<size_t N>
-		void generateSuperscalarHash(SuperscalarProgram(&programs)[N], std::vector<uint64_t> &) {
+
+		void generateSuperscalarHash(SuperscalarProgramList& programs, std::vector<uint64_t> &) {
 
 		}
 		void generateDatasetInitCode() {

--- a/src/jit_compiler_x86.hpp
+++ b/src/jit_compiler_x86.hpp
@@ -38,19 +38,21 @@ namespace randomx {
 	class Program;
 	struct ProgramConfiguration;
 	class SuperscalarProgram;
+	template<randomx_flags vmFlags>
 	class JitCompilerX86;
 	class Instruction;
 
-	typedef void(JitCompilerX86::*InstructionGeneratorX86)(Instruction&, int);
+	template<randomx_flags vmFlags>
+	using InstructionGeneratorX86 = void(JitCompilerX86<vmFlags>::*)(Instruction&, int);
 
+	template<randomx_flags vmFlags>
 	class JitCompilerX86 {
 	public:
 		JitCompilerX86();
 		~JitCompilerX86();
 		void generateProgram(Program&, ProgramConfiguration&);
 		void generateProgramLight(Program&, ProgramConfiguration&, uint32_t);
-		template<size_t N>
-		void generateSuperscalarHash(SuperscalarProgram (&programs)[N], std::vector<uint64_t> &);
+		void generateSuperscalarHash(SuperscalarProgramList &programs, std::vector<uint64_t> &);
 		void generateDatasetInitCode();
 		ProgramFunc* getProgramFunc() {
 			return (ProgramFunc*)code;
@@ -66,7 +68,7 @@ namespace randomx {
 		void enableExecution();
 		void enableAll();
 	private:
-		static InstructionGeneratorX86 engine[256];
+		static InstructionGeneratorX86<vmFlags> engine[256];
 		std::vector<int32_t> instructionOffsets;
 		int registerUsage[RegistersCount];
 		uint8_t* code;

--- a/src/randomx.h
+++ b/src/randomx.h
@@ -48,7 +48,8 @@ typedef enum {
   RANDOMX_FLAG_SECURE = 16,
   RANDOMX_FLAG_ARGON2_SSSE3 = 32,
   RANDOMX_FLAG_ARGON2_AVX2 = 64,
-  RANDOMX_FLAG_ARGON2 = 96
+  RANDOMX_FLAG_ARGON2 = 96,
+  RANDOMX_FLAG_V2 = 128,
 } randomx_flags;
 
 typedef struct randomx_dataset randomx_dataset;

--- a/src/tests/benchmark.cpp
+++ b/src/tests/benchmark.cpp
@@ -395,7 +395,7 @@ int main(int argc, char** argv) {
 		std::cout << "Calculated result: ";
 		result.print(std::cout);
 		if (noncesCount == 1000 && seedValue == 0 && !commit)
-			std::cout << "Reference result:  10b649a3f15c7c7f88277812f2e74b337a0f20ce909af09199cccb960771cfa1" << std::endl;
+			std::cout << "Reference result:  ff5326fbba7402e7af3373b25f10dbf71be0a4be91fc5a0db6af8b9faf708ed3" << std::endl;
 		if (!miningMode) {
 			std::cout << "Performance: " << 1000 * elapsed / noncesCount << " ms per hash" << std::endl;
 		}


### PR DESCRIPTION
    * CFROUND becomes conditional with a 1/16 chance of writing into fprc
    * F and E registers are mixed together with AES instead of XOR

This PR is incomplete. Currently, only the X86 and portable versions work, hardware AES is needed and the changes are hardcoded. But it's enough to run some benchmarks.

* [x] CFROUND changes in the interpreter
* [x] CFROUND changes in X86 JIT compiler
* [ ] CFROUND changes in A64 JIT compiler
* [ ] V1/V2 selectable at runtime
* [x] New portable intrinsics
* [x] New X86 instrinsics
* [ ] New ARM64 instrinsics
* [ ] New PowerPC intrinsics
* [ ] Support for soft AES in JIT compiler