### PR TITLE
Avoid redundant CI runs

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,6 +1,9 @@
 name: C/C++ CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   build-alpine:


### PR DESCRIPTION
Currently, CI jobs run twice for every push to a branch that has an open pull request.

This should limit CI runs only to pushes to master or PR ~~opened against master~~.