### PR TITLE
tests: include stdint.h

### DIFF
--- a/src/tests/utility.hpp
+++ b/src/tests/utility.hpp
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdlib>
 #include <iostream>
 #include <fstream>
+#include <stdint.h>
 
 constexpr char hexmap[] = "0123456789abcdef";
 inline void outputHex(std::ostream& os, const char* data, int length) {


### PR DESCRIPTION
  In file included from /var/tmp/portage/dev-libs/randomx-1.1.10/work/RandomX-1.1.10/src/tests/tests.cpp:7:
  /var/tmp/portage/dev-libs/randomx-1.1.10/work/RandomX-1.1.10/src/tests/utility.hpp:74:38: error: ‘uint64_t’ has not been declared