### PR TITLE
More faster init cache creation

### DIFF
--- a/src/randomx.cpp
+++ b/src/randomx.cpp
@@ -127,14 +127,15 @@ extern "C" {
 		return cache;
 	}
 
-	void randomx_init_cache(randomx_cache *cache, const void *key, size_t keySize) {
+	void randomx_init_cache(randomx_cache* cache, const void* key, size_t keyLength) {
 		assert(cache != nullptr);
-		assert(keySize == 0 || key != nullptr);
-		std::string cacheKey;
-		cacheKey.assign((const char *)key, keySize);
-		if (cache->cacheKey != cacheKey || !cache->isInitialized()) {
-			cache->initialize(cache, key, keySize);
-			cache->cacheKey = cacheKey;
+		assert(keyLength == 0 || key != nullptr);
+
+		std::string newCacheKey(static_cast<const char*>(key), keyLength);
+
+		if (cache->cacheKey != newCacheKey || !cache->isInitialized()) {
+			cache->initialize(cache, key, keyLength);
+			cache->cacheKey = std::move(newCacheKey);
 		}
 	}
 

--- a/src/vm_compiled.cpp
+++ b/src/vm_compiled.cpp
@@ -5,14 +5,14 @@ All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
-	* Redistributions of source code must retain the above copyright
-	  notice, this list of conditions and the following disclaimer.
-	* Redistributions in binary form must reproduce the above copyright
-	  notice, this list of conditions and the following disclaimer in the
-	  documentation and/or other materials provided with the distribution.
-	* Neither the name of the copyright holder nor the
-	  names of its contributors may be used to endorse or promote products
-	  derived from this software without specific prior written permission.
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -31,50 +31,50 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace randomx {
 
-	static_assert(sizeof(MemoryRegisters) == 2 * sizeof(addr_t) + sizeof(uintptr_t), "Invalid alignment of struct randomx::MemoryRegisters");
-	static_assert(sizeof(RegisterFile) == 256, "Invalid alignment of struct randomx::RegisterFile");
+    static_assert(sizeof(MemoryRegisters) == 2 * sizeof(addr_t) + sizeof(uintptr_t), "Invalid alignment of struct randomx::MemoryRegisters");
+    static_assert(sizeof(RegisterFile) == 256, "Invalid alignment of struct randomx::RegisterFile");
 
-	template<class Allocator, bool softAes, bool secureJit>
-	CompiledVm<Allocator, softAes, secureJit>::CompiledVm() {
-		if (!secureJit) {
-			compiler.enableAll(); //make JIT buffer both writable and executable
-		}
-	}
+    template<class Allocator, bool softAes, bool secureJit>
+    CompiledVm<Allocator, softAes, secureJit>::CompiledVm() {
+        if (!secureJit) {
+            compiler.enableAll(); // make JIT buffer both writable and executable
+        }
+    }
 
-	template<class Allocator, bool softAes, bool secureJit>
-	void CompiledVm<Allocator, softAes, secureJit>::setDataset(randomx_dataset* dataset) {
-		datasetPtr = dataset;
-	}
+    template<class Allocator, bool softAes, bool secureJit>
+    void CompiledVm<Allocator, softAes, secureJit>::setDataset(randomx_dataset* dataset) {
+        datasetPtr = dataset;
+    }
 
-	template<class Allocator, bool softAes, bool secureJit>
-	void CompiledVm<Allocator, softAes, secureJit>::run(void* seed) {
-		VmBase<Allocator, softAes>::generateProgram(seed);
-		randomx_vm::initialize();
-		if (secureJit) {
-			compiler.enableWriting();
-		}
-		compiler.generateProgram(program, config);
-		if (secureJit) {
-			compiler.enableExecution();
-		}
-		mem.memory = datasetPtr->memory + datasetOffset;
-		execute();
-	}
+    template<class Allocator, bool softAes, bool secureJit>
+    void CompiledVm<Allocator, softAes, secureJit>::run(void* seed) {
+        VmBase<Allocator, softAes>::generateProgram(seed);
+        randomx_vm::initialize();
+        if (secureJit) {
+            compiler.enableWriting();
+        }
+        compiler.generateProgram(program, config);
+        if (secureJit) {
+            compiler.enableExecution();
+        }
+        mem.memory = datasetPtr->memory + datasetOffset;
+        execute();
+    }
 
-	template<class Allocator, bool softAes, bool secureJit>
-	void CompiledVm<Allocator, softAes, secureJit>::execute() {
+    template<class Allocator, bool softAes, bool secureJit>
+    void CompiledVm<Allocator, softAes, secureJit>::execute() {
 #ifdef __aarch64__
-		memcpy(reg.f, config.eMask, sizeof(config.eMask));
+        memcpy(reg.f, config.eMask, sizeof(config.eMask));
 #endif
-		compiler.getProgramFunc()(reg, mem, scratchpad, RANDOMX_PROGRAM_ITERATIONS);
-	}
+        compiler.getProgramFunc()(reg, mem, scratchpad, RANDOMX_PROGRAM_ITERATIONS);
+    }
 
-	template class CompiledVm<AlignedAllocator<CacheLineSize>, false, false>;
-	template class CompiledVm<AlignedAllocator<CacheLineSize>, true, false>;
-	template class CompiledVm<LargePageAllocator, false, false>;
-	template class CompiledVm<LargePageAllocator, true, false>;
-	template class CompiledVm<AlignedAllocator<CacheLineSize>, false, true>;
-	template class CompiledVm<AlignedAllocator<CacheLineSize>, true, true>;
-	template class CompiledVm<LargePageAllocator, false, true>;
-	template class CompiledVm<LargePageAllocator, true, true>;
+    template class CompiledVm<AlignedAllocator<CacheLineSize>, false, false>;
+    template class CompiledVm<AlignedAllocator<CacheLineSize>, true, false>;
+    template class CompiledVm<LargePageAllocator, false, false>;
+    template class CompiledVm<LargePageAllocator, true, false>;
+    template class CompiledVm<AlignedAllocator<CacheLineSize>, false, true>;
+    template class CompiledVm<AlignedAllocator<CacheLineSize>, true, true>;
+    template class CompiledVm<LargePageAllocator, false, true>;
+    template class CompiledVm<LargePageAllocator, true, true>;
 }


### PR DESCRIPTION
Refactored randomx_init_dataset function in src/randomx.cpp -> running faster, than normal about .8 seconds.
Tested on Windows 11.