### PR TITLE
Fixed a crash on some systems when freeing memory

### DIFF
--- a/src/virtual_memory.c
+++ b/src/virtual_memory.c
@@ -235,6 +235,9 @@ void freePagedMemory(void* ptr, size_t bytes) {
 #if defined(_WIN32) || defined(__CYGWIN__)
 	VirtualFree(ptr, 0, MEM_RELEASE);
 #else
-	munmap(ptr, bytes);
+	// some munmap implementations can crash on null pointer, despite what the manpage says
+	if (ptr) {
+		munmap(ptr, bytes);
+	}
 #endif
 }


### PR DESCRIPTION
Alpine Linux riscv64 P2Pool builds have this issue.
```
Thread 3 "libuv-worker" received signal SIGSEGV, Segmentation fault.
[Switching to LWP 744]
__munmap (start=0x0, len=2097152) at ./arch/riscv64/syscall_arch.h:28
warning: 28     ./arch/riscv64/syscall_arch.h: No such file or directory
(gdb) bt
#0  __munmap (start=0x0, len=2097152) at ./arch/riscv64/syscall_arch.h:28
#1  0x000000000011a8b2 in randomx::VmBase<randomx::LargePageAllocator, true>::~VmBase (this=0x7ffff28f9000, __in_chrg=<optimized out>)
    at /home/runner/work/p2pool/p2pool/external/src/RandomX/src/virtual_machine.cpp:102
#2  0x0000000000118d60 in randomx::CompiledVm<randomx::LargePageAllocator, true, false>::~CompiledVm (this=0x7ffff28f9000, __in_chrg=<optimized out>)
    at /home/runner/work/p2pool/p2pool/external/src/RandomX/src/vm_compiled.hpp:41
#3  randomx::CompiledLightVm<randomx::LargePageAllocator, true, false>::~CompiledLightVm (this=0x7ffff28f9000, __in_chrg=<optimized out>)
    at /home/runner/work/p2pool/p2pool/external/src/RandomX/src/vm_compiled_light.hpp:37
#4  randomx::CompiledLightVm<randomx::LargePageAllocator, true, false>::~CompiledLightVm (this=0x7ffff28f9000, __in_chrg=<optimized out>)
    at /home/runner/work/p2pool/p2pool/external/src/RandomX/src/vm_compiled_light.hpp:37
#5  0x000000000011988e in randomx_create_vm (flags=<optimized out>, cache=0x7ffff29b61c0, dataset=0x0)
    at /home/runner/work/p2pool/p2pool/external/src/RandomX/src/randomx.cpp:334
#6  0x000000000006f4cc in p2pool::RandomX_Hasher::set_seed (this=0x7ffff29fa020, seed=...) at /home/runner/work/p2pool/p2pool/src/pow_hash.cpp:203
#7  0x000000000006fb44 in operator() (__closure=__closure@entry=0x0, req=0x7ffff2916d40) at /home/runner/work/p2pool/p2pool/src/pow_hash.cpp:147
#8  0x000000000006fb52 in _FUN () at /home/runner/work/p2pool/p2pool/src/pow_hash.cpp:149
#9  0x00000000000dcc8a in worker (arg=0x0) at /home/runner/work/p2pool/p2pool/external/src/libuv/src/threadpool.c:123
#10 0x00000000001d6e32 in start (p=0x7ffff6fdbab8) at src/thread/pthread_create.c:207
#11 0x00000000001d81fc in __clone () at src/thread/riscv64/clone.s:30
```