### PR TITLE
Update jit_compiler_a64_static.S

### DIFF
--- a/src/jit_compiler_a64_static.S
+++ b/src/jit_compiler_a64_static.S
@@ -44,6 +44,7 @@
 	.global DECL(randomx_program_aarch64_v2_FE_mix)
 	.global DECL(randomx_program_aarch64_v1_FE_mix)
 	.global DECL(randomx_program_aarch64_v2_FE_mix_soft_aes)
+	.hidden DECL(randomx_program_aarch64_aes_lut_pointers)
 	.global DECL(randomx_program_aarch64_aes_lut_pointers)
 	.global DECL(randomx_program_aarch64_vm_instructions_end_light)
 	.global DECL(randomx_program_aarch64_vm_instructions_end_light_tweak)

--- a/src/jit_compiler_a64_static.S
+++ b/src/jit_compiler_a64_static.S
@@ -44,7 +44,9 @@
 	.global DECL(randomx_program_aarch64_v2_FE_mix)
 	.global DECL(randomx_program_aarch64_v1_FE_mix)
 	.global DECL(randomx_program_aarch64_v2_FE_mix_soft_aes)
-	.hidden DECL(randomx_program_aarch64_aes_lut_pointers)
+	#ifndef __APPLE__
+	.hidden _randomx_program_aarch64_aes_lut_pointers
+	#endif
 	.global DECL(randomx_program_aarch64_aes_lut_pointers)
 	.global DECL(randomx_program_aarch64_vm_instructions_end_light)
 	.global DECL(randomx_program_aarch64_vm_instructions_end_light_tweak)

--- a/src/jit_compiler_a64_static.S
+++ b/src/jit_compiler_a64_static.S
@@ -45,7 +45,7 @@
 	.global DECL(randomx_program_aarch64_v1_FE_mix)
 	.global DECL(randomx_program_aarch64_v2_FE_mix_soft_aes)
 	#ifndef __APPLE__
-	.hidden _randomx_program_aarch64_aes_lut_pointers
+	.hidden DECL(randomx_program_aarch64_aes_lut_pointers)
 	#endif
 	.global DECL(randomx_program_aarch64_aes_lut_pointers)
 	.global DECL(randomx_program_aarch64_vm_instructions_end_light)


### PR DESCRIPTION
Fix RandomX fails to build as shared library on AArch64 due to non-PIC assembly symbol (ADR relocation error)

https://github.com/tevador/RandomX/issues/321