### PR TITLE
jit/a64: avoid redundant icache flush on macOS after generateProgram

### DIFF
--- a/src/jit_compiler_a64.cpp
+++ b/src/jit_compiler_a64.cpp
@@ -116,7 +116,7 @@ void JitCompilerA64::enableWriting()
 
 void JitCompilerA64::enableExecution()
 {
-	setPagesRX(code, CodeSize + CalcDatasetItemSize);
+	setPagesRXKeepIcache(code, CodeSize + CalcDatasetItemSize);
 }
 
 void JitCompilerA64::enableAll()

--- a/src/virtual_memory.c
+++ b/src/virtual_memory.c
@@ -198,6 +198,22 @@ void setPagesRX(void* ptr, size_t bytes) {
 #endif
 }
 
+void setPagesRXKeepIcache(void* ptr, size_t bytes) {
+#if defined(USE_PTHREAD_JIT_WP) && defined(MAC_OS_VERSION_11_0) \
+	&& MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0
+	if (__builtin_available(macOS 11.0, *)) {
+		/* The A64 JIT already called __builtin___clear_cache on the exact
+		   modified range inside generateProgram. Only toggle write-protect
+		   here; re-flushing the full buffer is redundant and measurably
+		   expensive on Apple Silicon. */
+		pthread_jit_write_protect_np(1);
+		return;
+	}
+#endif
+	char *errfunc;
+	pageProtect(ptr, bytes, PAGE_EXECUTE_READ, &errfunc);
+}
+
 void setPagesRWX(void* ptr, size_t bytes) {
 	char *errfunc;
 	pageProtect(ptr, bytes, PAGE_EXECUTE_READWRITE, &errfunc);

--- a/src/virtual_memory.h
+++ b/src/virtual_memory.h
@@ -39,6 +39,7 @@ extern "C" {
 void* allocMemoryPages(size_t);
 void setPagesRW(void*, size_t);
 void setPagesRX(void*, size_t);
+void setPagesRXKeepIcache(void*, size_t);
 void setPagesRWX(void*, size_t);
 void* allocLargePagesMemory(size_t);
 void freePagedMemory(void*, size_t);


### PR DESCRIPTION
This is my first *ever* PR for an open-source project so bear with me.
The intent was to improve H/Joule performance on Apple Silicon.
I used Claude Code to do research on the problem and to identify areas for improvement.
Of all the areas that we tested, this was the only one that was worth attempting to improve. (yielding between 1-3% improvement)
Mea Culpa:  The code was written by Claude.  I want to be clear about that up-front.  The specific instructions given indicated:
1. No harm
2. No touching anything except code pertaining to Apple Silicon
3. Clear testing to demonstrate improvement
4. Clear documentation to demonstrate what was changed.

Hopefully, this is something beneficial to RandomX.

-TS Abdallah
(Erie, Colorado)


# PR: jit/a64: avoid redundant icache flush on macOS after generateProgram

**Branch:** `apple-silicon-jit-icache-fix`
**Target:** `tevador/RandomX` master
**Commit:** 199f910

---

## Problem

On macOS 11+ (all Apple Silicon), `JitCompilerA64::enableExecution` calls
`setPagesRX`, which flushes the entire 20 KB JIT code buffer via
`__builtin___clear_cache` on every hash iteration.

This flush is redundant. `generateProgram` (and `generateProgramLight` /
`generateSuperscalarHash`) already calls `__builtin___clear_cache` over the
exact modified range immediately before `enableExecution` is invoked — see
`jit_compiler_a64.cpp` lines 214, 311, 428. The full-buffer flush in
`setPagesRX` re-invalidates bytes that were just cleaned, covering a ~5×
larger range than what was written.

On Apple Silicon, `sys_icache_invalidate` serialises the instruction
pipeline. Profiling on M4 Pro with `sample` shows this call consuming
**~3% of all CPU samples**, rooted in the `setPagesRX` path inside
`enableExecution`.

---

## Fix

Add `setPagesRXKeepIcache` to `virtual_memory.c/h`. On the macOS 11+ path
it calls only `pthread_jit_write_protect_np(1)` — toggling write-protect
without the redundant cache flush. On all other platforms it falls through
to the identical `pageProtect(PAGE_EXECUTE_READ)` call that `setPagesRX`
uses, so behaviour is completely unchanged outside macOS.

`JitCompilerA64::enableExecution` switches to `setPagesRXKeepIcache`.

---

## Call-site verification

Every call to `enableExecution` on the A64 JIT is preceded by a targeted
`__builtin___clear_cache` from a generate function:

| Call site | Preceding flush |
|---|---|
| `CompiledVm::run()` | `generateProgram` → `clear_cache(MainLoopBegin, codePos)` |
| `CompiledLightVm::run()` | `generateProgramLight` → `clear_cache(MainLoopBegin, codePos)` |
| `CompiledLightVm::setCache()` | `generateSuperscalarHash` → `clear_cache(CodeSize, codePos)` |
| `dataset.cpp::initCacheCompile()` | `generateSuperscalarHash` → `generateDatasetInitCode` (empty on A64) |

There are no early-return paths that skip the generate-function flush.

---

## Platform impact

| Platform | Behaviour |
|---|---|
| macOS 11+ / Apple Silicon | `enableExecution` skips redundant flush |
| macOS < 11 | Falls through to `pageProtect` — identical to before |
| Linux / Windows / other | Falls through to `pageProtect` — identical to before |
| x86 / RV64 JIT backends | Not affected — only `JitCompilerA64::enableExecution` changes |

**Note on x86:** `JitCompilerX86::generateProgram` does not call
`__builtin___clear_cache`, so its flush in `enableExecution` is the only
one and is not redundant. Left unchanged.

**Note on RV64:** `jit_compiler_rv64.cpp::enableExecution` has the same
redundant double-flush pattern as A64 (both `generateProgram` and
`enableExecution` call cache flush functions). That is out of scope here.

---

## Evidence

**Profiler (primary):** `sample` on a 30-second run shows
`sys_icache_invalidate` consuming ~3% of CPU samples, all rooted in
`setPagesRX` inside `enableExecution`. This code path is eliminated by
the patch.

**Benchmark (supporting):**
- Hardware: Apple M4 Pro, 10 P-cores, 48 GB, macOS 26.5.1
- Compiler: Apple clang 21.0.0 (`-march=armv8-a+crypto -mcpu=apple-m4 -O3`)
- Flags: `--mine --jit --init 10 --threads 10 --nonces 480000`

| | Baseline (n=7) | Patched (n=7) | Δ |
|---|---|---|---|
| Mean H/s | 5534.8 | 5601.2 | +66 (+1.2%) |
| Stdev | 57.5 | 28.7 | variance reduced |

The benchmark delta (+1–3% across trial sets) is within the noise floor of
a single-session comparison. The directional signal is consistent and the
reduced variance in the patched binary (stdev 29 vs 58) is consistent with
removing irregular pipeline-serialising flushes.

**Correctness:** Hash output identical to unpatched binary for identical
nonce sequences (`--verify --jit --nonces 5` →
`9b00372136cc7b31ba871e198d9ed1a57bd5d2f5616249009aba753cfa4cd413`).

---

## Related branches

**`pr-applearm`** (`4d940e9`) is a stale unmerged branch that proposes
replacing `__builtin___clear_cache` with `sys_icache_invalidate` in
`generateProgram`, `generateProgramLight`, and `generateSuperscalarHash`.
That branch is based on `virtual_memory.hpp` (since renamed to `.h`) and
does not apply cleanly to current master. It is complementary to this
patch: it would make the generation-time flush faster, while this patch
eliminates the redundant second flush. They could coexist without conflict.

**`pr-applejit`** (`8de238a`) proposed `pthread_jit_write_protect_np` in
`setPagesRW`/`setPagesRX` directly; the core idea was subsequently
incorporated into master in a more complete form.

---

## Files changed

```
src/virtual_memory.h   +1 line   — declare setPagesRXKeepIcache
src/virtual_memory.c   +16 lines — implement setPagesRXKeepIcache
src/jit_compiler_a64.cpp  +1/-1  — use it in enableExecution
```

Total: 18 insertions, 1 deletion, 3 files.