### PR TITLE
Fix: incorrect read dataset size was added

### DIFF
--- a/src/jit_compiler_x86.cpp
+++ b/src/jit_compiler_x86.cpp
@@ -321,11 +321,12 @@ namespace randomx {
 		generateProgramPrologue(prog, pcfg);
 		if (vmFlags & RANDOMX_FLAG_V2) {
 			memcpy(code + codePos, codeReadDatasetV2, readDatasetV2Size);
+			codePos += readDatasetV2Size;
 		}
 		else {
 			memcpy(code + codePos, codeReadDataset, readDatasetSize);
+			codePos += readDatasetSize;
 		}
-		codePos += readDatasetSize;
 		generateProgramEpilogue(prog, pcfg);
 	}
 


### PR DESCRIPTION
It only worked because both variables are equal at the moment, but it can change if V2 dataset read is rewritten.